### PR TITLE
feat: random gradient palette for CyberStrike logo

### DIFF
--- a/packages/cyberstrike/src/cli/cmd/tui/component/logo.tsx
+++ b/packages/cyberstrike/src/cli/cmd/tui/component/logo.tsx
@@ -1,5 +1,5 @@
 import { For } from "solid-js"
-import { useTheme } from "@tui/context/theme"
+import { useTheme, tint } from "@tui/context/theme"
 import { logo } from "@/cli/logo"
 
 export function Logo() {
@@ -8,13 +8,18 @@ export function Logo() {
   return (
     <box>
       <For each={logo}>
-        {(line) => (
-          <box flexDirection="row">
-            <text fg={theme.text} selectable={false}>
-              {line}
-            </text>
-          </box>
-        )}
+        {(line, index) => {
+          // Vertical gradient: top lines use text color, bottom lines fade toward background
+          const t = logo.length > 1 ? index() / (logo.length - 1) : 0
+          const color = tint(theme.background, theme.text, 1 - t * 0.6)
+          return (
+            <box flexDirection="row">
+              <text fg={color} selectable={false}>
+                {line}
+              </text>
+            </box>
+          )
+        }}
       </For>
     </box>
   )

--- a/packages/cyberstrike/src/cli/logo.ts
+++ b/packages/cyberstrike/src/cli/logo.ts
@@ -6,3 +6,65 @@ export const logo = [
   " ╚██████╗    ██║    ██████╔╝ ███████╗ ██║  ██║ ███████║    ██║    ██║  ██║ ██║ ██║  ██╗ ███████╗",
   "  ╚═════╝    ╚═╝    ╚═════╝  ╚══════╝ ╚═╝  ╚═╝ ╚══════╝    ╚═╝    ╚═╝  ╚═╝ ╚═╝ ╚═╝  ╚═╝ ╚══════╝",
 ]
+
+// Palettes from oh-my-logo — each is an array of hex color stops for gradient
+export const palettes = {
+  "matrix":    ["#00ff41", "#008f11"],
+  "fire":      ["#ff0844", "#ffb199"],
+  "forest":    ["#134e5e", "#71b280"],
+  "ocean":     ["#667eea", "#764ba2"],
+  "sunset":    ["#ff9966", "#ff5e62", "#ffa34e"],
+  "dawn":      ["#00c6ff", "#0072ff"],
+  "nebula":    ["#654ea3", "#eaafc8"],
+  "gold":      ["#f7971e", "#ffd200"],
+  "purple":    ["#667db6", "#0082c8", "#0078ff"],
+  "mint":      ["#00d2ff", "#3a7bd5"],
+  "coral":     ["#ff9a9e", "#fecfef"],
+  "grad-blue": ["#4ea8ff", "#7f88ff"],
+  "mono":      ["#f07178", "#f07178"],
+} as const
+
+export type PaletteName = keyof typeof palettes
+
+// Parse "#rrggbb" to [r, g, b]
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "")
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)]
+}
+
+// Interpolate between color stops at position t (0..1)
+function interpolate(stops: [number, number, number][], t: number): [number, number, number] {
+  if (stops.length === 1) return stops[0]
+  const segment = t * (stops.length - 1)
+  const i = Math.min(Math.floor(segment), stops.length - 2)
+  const f = segment - i
+  const a = stops[i]
+  const b = stops[i + 1]
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * f),
+    Math.round(a[1] + (b[1] - a[1]) * f),
+    Math.round(a[2] + (b[2] - a[2]) * f),
+  ]
+}
+
+/**
+ * Apply vertical gradient to the logo lines using the given palette.
+ * Each line gets a color interpolated from the palette stops.
+ * Returns array of ANSI-colored strings.
+ */
+export function colorize(paletteName?: PaletteName): string[] {
+  const name = paletteName ?? randomPalette()
+  const colors = palettes[name]
+  const stops = colors.map(hexToRgb)
+
+  return logo.map((line, i) => {
+    const t = logo.length > 1 ? i / (logo.length - 1) : 0
+    const [r, g, b] = interpolate(stops, t)
+    return `\x1b[38;2;${r};${g};${b}m${line}\x1b[0m`
+  })
+}
+
+export function randomPalette(): PaletteName {
+  const names = Object.keys(palettes) as PaletteName[]
+  return names[Math.floor(Math.random() * names.length)]
+}

--- a/packages/cyberstrike/src/cli/ui.ts
+++ b/packages/cyberstrike/src/cli/ui.ts
@@ -1,7 +1,7 @@
 import z from "zod"
 import { EOL } from "os"
 import { NamedError } from "@cyberstrikeus/util/error"
-import { logo as lines } from "./logo"
+import { colorize } from "./logo"
 
 export namespace UI {
   export const CancelledError = NamedError.create("UICancelledError", z.void())
@@ -41,12 +41,11 @@ export namespace UI {
   }
 
   export function logo(pad?: string) {
+    const lines = colorize()
     const result: string[] = []
-    const reset = "\x1b[0m"
-    const fg = "\x1b[32m" // green (forest theme)
     for (const line of lines) {
       if (pad) result.push(pad)
-      result.push(fg, line, reset, EOL)
+      result.push(line, EOL)
     }
     return result.join("").trimEnd()
   }


### PR DESCRIPTION
## Summary

- 13 color palettes (matrix, fire, forest, ocean, sunset, dawn, nebula, gold, purple, mint, coral, grad-blue, mono) — same as oh-my-logo
- CLI: random palette on each startup, vertical gradient applied per-line
- TUI: theme-aware gradient (uses theme text/background colors, updates on theme change)
- Zero external dependency — gradient interpolation in `logo.ts` (~40 lines)

## Test plan

- [ ] Run `cyberstrike` multiple times — logo color changes each time
- [ ] Change TUI theme — logo gradient follows theme colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)