### PR TITLE
fix: use badchars for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: CyberStrikeus
+github: badchars
 buy_me_a_coffee: orhanyildirim


### PR DESCRIPTION
CyberStrikeus org is not enrolled in GitHub Sponsors. Use badchars (enrolled) instead.