### PR TITLE
docs: add section navigation bar to all READMEs

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#لماذا-cyberstrike؟">لماذا CyberStrike؟</a> &bull;
+  <a href="#ما-الذي-يجعله-مختلفاً">ما الذي يجعله مختلفاً</a> &bull;
+  <a href="#الوكلاء">الوكلاء</a> &bull;
+  <a href="#منظومة-mcp">منظومة MCP</a> &bull;
+  <a href="#التثبيت">التثبيت</a> &bull;
+  <a href="#الأدوات-المدمجة">الأدوات المدمجة</a> &bull;
+  <a href="#لمن-هذا؟">لمن هذا؟</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### لماذا CyberStrike؟

--- a/README.bn.md
+++ b/README.bn.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#কেন-cyberstrike">কেন CyberStrike?</a> &bull;
+  <a href="#কী-এটিকে-আলাদা-করে">কী এটিকে আলাদা করে</a> &bull;
+  <a href="#এজেন্ট">এজেন্ট</a> &bull;
+  <a href="#mcp-ইকোসিস্টেম">MCP ইকোসিস্টেম</a> &bull;
+  <a href="#ইনস্টলেশন">ইনস্টলেশন</a> &bull;
+  <a href="#বিল্ট-ইন-টুল">বিল্ট-ইন টুল</a> &bull;
+  <a href="#এটি-কাদের-জন্য">এটি কাদের জন্য?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### কেন CyberStrike?

--- a/README.br.md
+++ b/README.br.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#por-que-cyberstrike">Por que CyberStrike?</a> &bull;
+  <a href="#o-que-o-torna-diferente">O que o torna diferente</a> &bull;
+  <a href="#agentes">Agentes</a> &bull;
+  <a href="#ecossistema-mcp">Ecossistema MCP</a> &bull;
+  <a href="#instalacao">Instalacao</a> &bull;
+  <a href="#ferramentas-integradas">Ferramentas integradas</a> &bull;
+  <a href="#para-quem-e-isso">Para quem e isso?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Por que CyberStrike?

--- a/README.bs.md
+++ b/README.bs.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#zašto-cyberstrike">Zašto CyberStrike?</a> &bull;
+  <a href="#po-čemu-se-razlikuje">Po čemu se razlikuje</a> &bull;
+  <a href="#agenti">Agenti</a> &bull;
+  <a href="#mcp-ekosistem">MCP ekosistem</a> &bull;
+  <a href="#instalacija">Instalacija</a> &bull;
+  <a href="#ugrađeni-alati">Ugrađeni alati</a> &bull;
+  <a href="#kome-je-ovo-namijenjeno">Kome je ovo namijenjeno?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Zašto CyberStrike?

--- a/README.da.md
+++ b/README.da.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#hvorfor-cyberstrike">Hvorfor CyberStrike?</a> &bull;
+  <a href="#hvad-gør-det-anderledes">Hvad G&oslash;r Det Anderledes</a> &bull;
+  <a href="#agenter">Agenter</a> &bull;
+  <a href="#mcp-økosystem">MCP-&Oslash;kosystem</a> &bull;
+  <a href="#installation">Installation</a> &bull;
+  <a href="#indbyggede-værktøjer">Indbyggede V&aelig;rkt&oslash;jer</a> &bull;
+  <a href="#hvem-er-det-til">Hvem Er Det Til?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Hvorfor CyberStrike?

--- a/README.de.md
+++ b/README.de.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#warum-cyberstrike">Warum CyberStrike?</a> &bull;
+  <a href="#was-macht-es-anders">Was macht es anders?</a> &bull;
+  <a href="#agenten">Agenten</a> &bull;
+  <a href="#mcp-oekosystem">MCP-Oekosystem</a> &bull;
+  <a href="#installation">Installation</a> &bull;
+  <a href="#integrierte-werkzeuge">Integrierte Werkzeuge</a> &bull;
+  <a href="#fuer-wen-ist-das">Fuer wen ist das?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Warum CyberStrike?

--- a/README.el.md
+++ b/README.el.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#γιατί-cyberstrike">Γιατί CyberStrike;</a> &bull;
+  <a href="#τι-το-κάνει-διαφορετικό">Τι το κάνει διαφορετικό</a> &bull;
+  <a href="#agents">Agents</a> &bull;
+  <a href="#οικοσύστημα-mcp">Οικοσύστημα MCP</a> &bull;
+  <a href="#εγκατάσταση">Εγκατάσταση</a> &bull;
+  <a href="#ενσωματωμένα-εργαλεία">Ενσωματωμένα εργαλεία</a> &bull;
+  <a href="#για-ποιον-είναι">Για ποιον είναι;</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Γιατί CyberStrike;

--- a/README.es.md
+++ b/README.es.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#por-que-cyberstrike">Por que CyberStrike?</a> &bull;
+  <a href="#que-lo-hace-diferente">Que lo hace diferente</a> &bull;
+  <a href="#agentes">Agentes</a> &bull;
+  <a href="#ecosistema-mcp">Ecosistema MCP</a> &bull;
+  <a href="#instalacion">Instalacion</a> &bull;
+  <a href="#herramientas-integradas">Herramientas integradas</a> &bull;
+  <a href="#para-quien-es">Para quien es?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Por que CyberStrike?

--- a/README.fr.md
+++ b/README.fr.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#pourquoi-cyberstrike">Pourquoi CyberStrike ?</a> &bull;
+  <a href="#ce-qui-le-differencie">Ce qui le differencie</a> &bull;
+  <a href="#agents">Agents</a> &bull;
+  <a href="#ecosysteme-mcp">Ecosysteme MCP</a> &bull;
+  <a href="#installation">Installation</a> &bull;
+  <a href="#outils-integres">Outils integres</a> &bull;
+  <a href="#a-qui-sadresse-t-il">A qui s'adresse-t-il ?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Pourquoi CyberStrike ?

--- a/README.hi.md
+++ b/README.hi.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#cyberstrike-क्यों">CyberStrike क्यों?</a> &bull;
+  <a href="#यह-अलग-क्या-बनाता-है">यह अलग क्या बनाता है</a> &bull;
+  <a href="#एजेंट">एजेंट</a> &bull;
+  <a href="#mcp-इकोसिस्टम">MCP इकोसिस्टम</a> &bull;
+  <a href="#इंस्टॉलेशन">इंस्टॉलेशन</a> &bull;
+  <a href="#बिल्ट-इन-टूल्स">बिल्ट-इन टूल्स</a> &bull;
+  <a href="#यह-किसके-लिए-है">यह किसके लिए है?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### CyberStrike क्यों?

--- a/README.it.md
+++ b/README.it.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#perché-cyberstrike">Perch&eacute; CyberStrike?</a> &bull;
+  <a href="#cosa-lo-rende-diverso">Cosa Lo Rende Diverso</a> &bull;
+  <a href="#agenti">Agenti</a> &bull;
+  <a href="#ecosistema-mcp">Ecosistema MCP</a> &bull;
+  <a href="#installazione">Installazione</a> &bull;
+  <a href="#strumenti-integrati">Strumenti Integrati</a> &bull;
+  <a href="#a-chi-è-rivolto">A Chi &Egrave; Rivolto?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Perch&eacute; CyberStrike?

--- a/README.ja.md
+++ b/README.ja.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#なぜ-cyberstrike-なのか？">なぜ CyberStrike なのか？</a> &bull;
+  <a href="#何が違うのか">何が違うのか</a> &bull;
+  <a href="#エージェント">エージェント</a> &bull;
+  <a href="#mcp-エコシステム">MCP エコシステム</a> &bull;
+  <a href="#インストール">インストール</a> &bull;
+  <a href="#組み込みツール">組み込みツール</a> &bull;
+  <a href="#誰のためのものか">誰のためのものか</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### なぜ CyberStrike なのか？

--- a/README.ko.md
+++ b/README.ko.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#왜-cyberstrike인가">왜 CyberStrike인가?</a> &bull;
+  <a href="#무엇이-다른가">무엇이 다른가</a> &bull;
+  <a href="#에이전트">에이전트</a> &bull;
+  <a href="#mcp-생태계">MCP 생태계</a> &bull;
+  <a href="#설치">설치</a> &bull;
+  <a href="#내장-도구">내장 도구</a> &bull;
+  <a href="#누구를-위한-것인가">누구를 위한 것인가</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### 왜 CyberStrike인가?

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#why-cyberstrike">Why CyberStrike?</a> &bull;
+  <a href="#what-makes-it-different">What Makes It Different</a> &bull;
+  <a href="#agents">Agents</a> &bull;
+  <a href="#mcp-ecosystem">MCP Ecosystem</a> &bull;
+  <a href="#installation">Installation</a> &bull;
+  <a href="#built-in-tools">Built-in Tools</a> &bull;
+  <a href="#who-is-this-for">Who Is This For?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Why CyberStrike?

--- a/README.no.md
+++ b/README.no.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#hvorfor-cyberstrike">Hvorfor CyberStrike?</a> &bull;
+  <a href="#hva-gjør-det-annerledes">Hva gjør det annerledes</a> &bull;
+  <a href="#agenter">Agenter</a> &bull;
+  <a href="#mcp-økosystemet">MCP-økosystemet</a> &bull;
+  <a href="#installasjon">Installasjon</a> &bull;
+  <a href="#innebygde-verktøy">Innebygde verktøy</a> &bull;
+  <a href="#hvem-er-dette-for">Hvem er dette for?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Hvorfor CyberStrike?

--- a/README.pl.md
+++ b/README.pl.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#dlaczego-cyberstrike">Dlaczego CyberStrike?</a> &bull;
+  <a href="#co-go-wyróżnia">Co Go Wyróżnia</a> &bull;
+  <a href="#agenci">Agenci</a> &bull;
+  <a href="#ekosystem-mcp">Ekosystem MCP</a> &bull;
+  <a href="#instalacja">Instalacja</a> &bull;
+  <a href="#wbudowane-narzędzia">Wbudowane Narzędzia</a> &bull;
+  <a href="#dla-kogo-to-jest">Dla Kogo To Jest?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Dlaczego CyberStrike?

--- a/README.ru.md
+++ b/README.ru.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#почему-cyberstrike">Почему CyberStrike?</a> &bull;
+  <a href="#чем-он-отличается">Чем Он Отличается</a> &bull;
+  <a href="#агенты">Агенты</a> &bull;
+  <a href="#экосистема-mcp">Экосистема MCP</a> &bull;
+  <a href="#установка">Установка</a> &bull;
+  <a href="#встроенные-инструменты">Встроенные Инструменты</a> &bull;
+  <a href="#для-кого-это">Для Кого Это?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Почему CyberStrike?

--- a/README.th.md
+++ b/README.th.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#ทำไมต้อง-cyberstrike">ทำไมต้อง CyberStrike?</a> &bull;
+  <a href="#อะไรทำให้มันแตกต่าง">อะไรทำให้มันแตกต่าง</a> &bull;
+  <a href="#เอเจนต์">เอเจนต์</a> &bull;
+  <a href="#ระบบนิเวศ-mcp">ระบบนิเวศ MCP</a> &bull;
+  <a href="#การติดตั้ง">การติดตั้ง</a> &bull;
+  <a href="#เครื่องมือในตัว">เครื่องมือในตัว</a> &bull;
+  <a href="#เหมาะสำหรับใคร">เหมาะสำหรับใคร?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### ทำไมต้อง CyberStrike?

--- a/README.tr.md
+++ b/README.tr.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#neden-cyberstrike">Neden CyberStrike?</a> &bull;
+  <a href="#farki-ne">Farki Ne?</a> &bull;
+  <a href="#ajanlar">Ajanlar</a> &bull;
+  <a href="#mcp-ekosistemi">MCP Ekosistemi</a> &bull;
+  <a href="#kurulum">Kurulum</a> &bull;
+  <a href="#yerlesik-araclar">Yerlesik Araclar</a> &bull;
+  <a href="#kimler-icin">Kimler Icin?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Neden CyberStrike?

--- a/README.uk.md
+++ b/README.uk.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#чому-cyberstrike">Чому CyberStrike?</a> &bull;
+  <a href="#що-робить-його-особливим">Що робить його особливим</a> &bull;
+  <a href="#агенти">Агенти</a> &bull;
+  <a href="#екосистема-mcp">Екосистема MCP</a> &bull;
+  <a href="#встановлення">Встановлення</a> &bull;
+  <a href="#вбудовані-інструменти">Вбудовані інструменти</a> &bull;
+  <a href="#для-кого-це">Для кого це?</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Чому CyberStrike?

--- a/README.vi.md
+++ b/README.vi.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#tại-sao-chọn-cyberstrike">Tại sao chọn CyberStrike?</a> &bull;
+  <a href="#điều-gì-khiến-cyberstrike-khác-biệt">Điều gì khiến CyberStrike khác biệt</a> &bull;
+  <a href="#tác-nhân">Tác nhân</a> &bull;
+  <a href="#hệ-sinh-thái-mcp">Hệ sinh thái MCP</a> &bull;
+  <a href="#cài-đặt">Cài đặt</a> &bull;
+  <a href="#công-cụ-tích-hợp-sẵn">Công cụ tích hợp sẵn</a> &bull;
+  <a href="#đối-tượng-sử-dụng">Đối tượng sử dụng</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### Tại sao chọn CyberStrike?

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#为什么选择-cyberstrike？">为什么选择 CyberStrike？</a> &bull;
+  <a href="#独特之处">独特之处</a> &bull;
+  <a href="#智能体">智能体</a> &bull;
+  <a href="#mcp-生态系统">MCP 生态系统</a> &bull;
+  <a href="#安装">安装</a> &bull;
+  <a href="#内置工具">内置工具</a> &bull;
+  <a href="#适用人群">适用人群</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### 为什么选择 CyberStrike？

--- a/README.zht.md
+++ b/README.zht.md
@@ -46,6 +46,18 @@
   <a href="README.hi.md">हिन्दी</a>
 </p>
 
+<p align="center">
+  <a href="#為什麼選擇-cyberstrike？">為什麼選擇 CyberStrike？</a> &bull;
+  <a href="#獨特之處">獨特之處</a> &bull;
+  <a href="#智能體">智能體</a> &bull;
+  <a href="#mcp-生態系統">MCP 生態系統</a> &bull;
+  <a href="#安裝">安裝</a> &bull;
+  <a href="#內建工具">內建工具</a> &bull;
+  <a href="#適用對象">適用對象</a> &bull;
+  <a href="CHANGELOG.md">Changelog</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
 ---
 
 ### 為什麼選擇 CyberStrike？


### PR DESCRIPTION
Adds clickable section navigation links (Why CyberStrike? • What Makes It Different • Agents • MCP Ecosystem • Installation • Built-in Tools • Who Is This For? • Changelog • Contributing) to all 23 README files. Each translated README uses anchors matching its own language headings.