### PR TITLE
fix(cyberstrike): 58 Correcting error preventing using of EC2 instance role via co…

### DIFF
--- a/packages/cyberstrike/src/provider/provider.ts
+++ b/packages/cyberstrike/src/provider/provider.ts
@@ -245,7 +245,7 @@ export namespace Provider {
         process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
       )
 
-      if (!profile && !awsAccessKeyId && !awsBearerToken && !awsWebIdentityTokenFile && !containerCreds)
+      if (!profile && !awsAccessKeyId && !awsBearerToken && !awsWebIdentityTokenFile && !containerCreds && !providerConfig)
         return { autoload: false }
 
       const providerOptions: AmazonBedrockProviderSettings = {
@@ -255,12 +255,17 @@ export namespace Provider {
       // Only use credential chain if no bearer token exists
       // Bearer token takes precedence over credential chain (profiles, access keys, IAM roles, web identity tokens)
       if (!awsBearerToken) {
-        const { fromNodeProviderChain } = await import(await BunProc.install("@aws-sdk/credential-providers"))
-
-        // Build credential provider options (only pass profile if specified)
-        const credentialProviderOptions = profile ? { profile } : {}
-
-        providerOptions.credentialProvider = fromNodeProviderChain(credentialProviderOptions)
+        if (awsAccessKeyId) {
+          // If explicit environment credentials are set, use standard env provider
+          const { fromEnv } = await import(await BunProc.install("@aws-sdk/credential-provider-env"))
+          providerOptions.credentialProvider = fromEnv()
+        } else {
+          // Direct IMDS provider for EC2 Instance Roles (bypasses file-loader symbol stubs)
+          const { fromInstanceMetadata } = await import(
+            await BunProc.install("@aws-sdk/credential-provider-imds")
+          )
+          providerOptions.credentialProvider = fromInstanceMetadata()
+        }
       }
 
       // Add custom endpoint if specified (endpoint takes precedence over baseURL)


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and why they're needed. Link the related issue with Fixes # or Closes #. -->
Fixes: [Issue 58](https://github.com/CyberStrikeus/CyberStrike/issues/58)
Updated line 248 in `packages/cyberstrike/src/provider/provider.ts` to include a check if a `providerConfig` was supplied. This previously caused an early exit if all items in the if statement were blank.

The second change started at line 258 resolved an issue where Bun would crash when parsing local file structures, with error `'parseKnownFiles' is a Symbol`.

## Type of change

- [X] Bug fix
- [ ] New feature / agent
- [ ] Security tool / MCP server / Bolt plugin
- [ ] Agent skill / knowledge base
- [ ] UI / TUI improvement
- [ ] Documentation
- [ ] Refactor / performance
- [ ] CI / infrastructure

## Security impact

- [ ] This PR adds or modifies tool execution (shell, file, network)
- [ ] This PR changes agent permissions or scope
- [ ] This PR modifies authentication / authorization logic
- [X] This PR has no security impact

## How did you verify it works?

<!-- Describe what you tested and how a reviewer can confirm. -->
Tested on EC2 that the config file is read and Cyberstrike can send prompts to Amazon Bedrock without API error using the attached EC2 Instance role.


## Checklist

- [X] `bun turbo typecheck` passes
- [X] Tested locally with at least one LLM provider
- [X] PR is focused on a single change
- [X] No secrets, credentials, or API keys in the diff
- [ ] Breaking changes are documented (if any)

<img width="624" height="796" alt="image" src="https://github.com/user-attachments/assets/ecf5cea3-0267-4b10-b62f-30f39ee4639f" />
