### PR TITLE
docs: document OrcaRouter as a supported provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ CyberStrike integrates with the entire AI ecosystem through 23 bundled SDK provi
 | **Cerebras**              | LLaMA on Cerebras        | Fastest inference available             |
 | **Cohere**                | Command R+               | RAG-optimized models                    |
 | **OpenRouter**            | 300+ models              | Single API, any model                   |
+| **OrcaRouter**            | 80+ models               | Single gateway for Claude, GPT & more   |
 | **Together AI**           | Open-source models       | Fine-tuning support                     |
 | **DeepInfra**             | Open-source models       | Pay-per-token, no GPU needed            |
 | **Perplexity**            | Sonar models             | Search-augmented generation             |


### PR DESCRIPTION
## Summary

Adds OrcaRouter to the README "core integrations" provider table so users can discover it as a supported gateway, alongside OpenRouter.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway exposing 80+ models across Claude, GPT, Gemini, DeepSeek and Qwen through a single API. CyberStrike's open-source AI agent for offensive security already supports it today: OrcaRouter ships in the [models.dev](https://models.dev) catalog (`api.npm` = `@ai-sdk/openai-compatible`, env `ORCAROUTER_API_KEY`) and resolves through the bundled openai-compatible SDK, so this change is documentation only.

## Checklist

- [x] Docs-only change, no code change

Fixes #64

I'm an engineer on the OrcaRouter team.
