### PR TITLE
fix(tui): dedupe concurrent bootstraps to prevent first-run freeze

### DIFF
--- a/packages/cyberstrike/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/cyberstrike/src/cli/cmd/tui/context/sync.tsx
@@ -28,6 +28,7 @@ import { useExit } from "./exit"
 import { useArgs } from "./args"
 import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
+import { singleflight } from "@/util/singleflight"
 import type { Path } from "@cyberstrike-io/sdk"
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
@@ -577,7 +578,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const exit = useExit()
     const args = useArgs()
 
-    async function bootstrap() {
+    const bootstrap = singleflight(async function () {
       console.log("bootstrapping")
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
@@ -664,7 +665,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           })
           await exit(e)
         })
-    }
+    })
 
     onMount(() => {
       bootstrap()

--- a/packages/cyberstrike/src/util/singleflight.ts
+++ b/packages/cyberstrike/src/util/singleflight.ts
@@ -1,0 +1,10 @@
+export function singleflight<T>(fn: () => Promise<T>) {
+  let inflight: Promise<T> | undefined
+  return () => {
+    if (inflight) return inflight
+    inflight = fn().finally(() => {
+      inflight = undefined
+    })
+    return inflight
+  }
+}

--- a/packages/cyberstrike/test/util/singleflight.test.ts
+++ b/packages/cyberstrike/test/util/singleflight.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test"
+import { singleflight } from "../../src/util/singleflight"
+
+function tick() {
+  return new Promise<void>((r) => queueMicrotask(r))
+}
+
+describe("util.singleflight", () => {
+  test("concurrent calls share one execution", async () => {
+    let count = 0
+    const run = singleflight(async () => {
+      count++
+      await tick()
+      return { value: Math.random() }
+    })
+
+    const [a, b] = await Promise.all([run(), run()])
+    expect(count).toBe(1)
+    expect(a).toBe(b)
+  })
+
+  test("executes again after the promise settles", async () => {
+    let count = 0
+    const run = singleflight(async () => {
+      count++
+      await tick()
+    })
+
+    await run()
+    await run()
+    expect(count).toBe(2)
+  })
+
+  test("rejection propagates to all callers and the guard clears", async () => {
+    let fail = true
+    let count = 0
+    const run = singleflight(async () => {
+      count++
+      await tick()
+      if (fail) throw new Error("boom")
+      return "ok"
+    })
+
+    const results = await Promise.allSettled([run(), run(), run()])
+    expect(count).toBe(1)
+    for (const result of results) {
+      expect(result.status).toBe("rejected")
+      if (result.status === "rejected") expect(result.reason.message).toBe("boom")
+    }
+
+    fail = false
+    expect(await run()).toBe("ok")
+    expect(count).toBe(2)
+  })
+
+  test("sequential non-overlapping calls each execute", async () => {
+    let count = 0
+    const run = singleflight(async () => {
+      count++
+      await tick()
+      return count
+    })
+
+    expect(await run()).toBe(1)
+    expect(await run()).toBe(2)
+    expect(await run()).toBe(3)
+    expect(count).toBe(3)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes #66.

During first-time provider setup, two bootstrap triggers fire concurrently:

- `dialog-provider.tsx` awaits `sync.bootstrap()` right after `instance.dispose()` (4 call sites)
- the SSE `server.instance.disposed` handler calls `bootstrap()` (`packages/cyberstrike/src/cli/cmd/tui/context/sync.tsx:301`)

The disposed event is emitted before the dispose response returns, so both runs overlap on the first-run auth flow and race the global store transitions. This wraps `bootstrap` in a new `singleflight` helper (`packages/cyberstrike/src/util/singleflight.ts`) so concurrent calls share one in-flight promise. The guard clears on settle, so later disposed/reload events still trigger a fresh bootstrap. Single, non-overlapping bootstraps behave exactly as before.

## Type of change

- [x] Bug fix
- [ ] New feature / agent
- [ ] Security tool / MCP server / Bolt plugin
- [ ] Agent skill / knowledge base
- [ ] UI / TUI improvement
- [ ] Documentation
- [ ] Refactor / performance
- [ ] CI / infrastructure

## Security impact

- [ ] This PR adds or modifies tool execution (shell, file, network)
- [ ] This PR changes agent permissions or scope
- [ ] This PR modifies authentication / authorization logic
- [x] This PR has no security impact

## How did you verify it works?

- New unit tests in `packages/cyberstrike/test/util/singleflight.test.ts` cover the dedup contract: concurrent calls share one execution, re-execution after the promise settles, rejection propagates to all callers and clears the guard, and sequential calls each run. `bun test test/util/` passes (28 tests) and `bun test test/cli/tui/` passes.
- `bun run typecheck` (tsgo) passes in `packages/cyberstrike`.

## Checklist

- [x] `bun turbo typecheck` passes
- [ ] Tested locally with at least one LLM provider
- [x] PR is focused on a single change
- [x] No secrets, credentials, or API keys in the diff
- [x] Breaking changes are documented (if any)