### PR TITLE
Sync main with stage: hackbrowser reliability chain + Copilot worker + canary channel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: "Bump major, minor, patch, or beta"
+        description: "Bump major, minor, patch, beta, or canary"
         required: false
         type: choice
         options:
@@ -13,6 +13,7 @@ on:
           - minor
           - patch
           - beta
+          - canary
       version:
         description: "Override version (optional)"
         required: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
         env:
           CYBERSTRIKE_VERSION: ${{ needs.version.outputs.version }}
           CYBERSTRIKE_RELEASE: ${{ needs.version.outputs.release }}
-          CYBERSTRIKE_BUILD_OS: ${{ inputs.platform == 'all' && '' || inputs.platform }}
+          CYBERSTRIKE_BUILD_OS: ${{ inputs.platform }}
           GH_TOKEN: ${{ github.token }}
 
       - uses: actions/upload-artifact@v4

--- a/packages/cyberstrike/.gitignore
+++ b/packages/cyberstrike/.gitignore
@@ -3,7 +3,7 @@ dist
 gen
 app.log
 src/provider/models-snapshot.ts
-cookies.txt
+cookies*.txt
 headers.txt
 jq
 postman/

--- a/packages/cyberstrike/script/build.ts
+++ b/packages/cyberstrike/script/build.ts
@@ -114,8 +114,9 @@ const allTargets: {
   },
 ]
 
-// CI-only: build just one OS when set (windows/linux/darwin). Empty = all.
-const buildOS = process.env.CYBERSTRIKE_BUILD_OS?.trim()
+// CI-only: build just one OS when set (windows/linux/darwin). Empty or "all" = every platform.
+const buildOSRaw = process.env.CYBERSTRIKE_BUILD_OS?.trim()
+const buildOS = buildOSRaw && buildOSRaw !== "all" ? buildOSRaw : undefined
 const targets = (singleFlag
   ? allTargets.filter((item) => {
       if (item.os !== process.platform || item.arch !== process.arch) {

--- a/packages/cyberstrike/src/hackbrowser-subprocess/hackbrowser-worker.ts
+++ b/packages/cyberstrike/src/hackbrowser-subprocess/hackbrowser-worker.ts
@@ -31,6 +31,63 @@ function send(msg: WorkerMessage): void {
 }
 
 // ============================================================
+// Crash safety net (#117)
+// ============================================================
+//
+// The worker does extensive async DOM work (page.evaluate, selectors, network
+// capture, event handlers). A single uncaught throw anywhere would otherwise
+// terminate the process and kill the whole multi-page crawl — one bad element
+// must never abort a 50-page run (#116). Captured requests are ingested to the
+// parent live, so continuing loses no data, and the BFS loop has its own
+// per-page try/catch + browser-death detection to terminate on real failure.
+const UNCAUGHT_LIMIT = 25
+const UNCAUGHT_WINDOW_MS = 15_000
+let uncaughtTimes: number[] = []
+
+function stringifyError(e: unknown): string {
+  if (e instanceof Error) return (e.stack ?? e.message).slice(0, 500)
+  try {
+    return String(e).slice(0, 500)
+  } catch {
+    return "<unstringifiable>"
+  }
+}
+
+function installCrashGuards(): void {
+  // An unhandledRejection escaped EVERY await, so the main runCrawl chain never
+  // depended on it (a fire-and-forget background promise). Log and continue.
+  process.on("unhandledRejection", (reason) => {
+    send({
+      type: "log",
+      level: "warn",
+      service: "hackbrowser:worker",
+      message: "unhandledRejection (crawl continues): " + stringifyError(reason),
+    })
+  })
+  // uncaughtException is a sync throw in a callback (event handler/timer) with
+  // no try/catch — usually background too. Continue, but bail if they flood:
+  // a genuinely corrupted browser/session, so stop rather than spin forever.
+  process.on("uncaughtException", (err) => {
+    send({
+      type: "log",
+      level: "error",
+      service: "hackbrowser:worker",
+      message: "uncaughtException (crawl continues): " + stringifyError(err),
+    })
+    const now = Date.now()
+    uncaughtTimes.push(now)
+    uncaughtTimes = uncaughtTimes.filter((t) => now - t < UNCAUGHT_WINDOW_MS)
+    if (uncaughtTimes.length > UNCAUGHT_LIMIT) {
+      send({
+        type: "error",
+        message: `worker aborted after ${uncaughtTimes.length} uncaught exceptions in ${UNCAUGHT_WINDOW_MS / 1000}s — likely a corrupted browser/session`,
+      })
+      process.exit(1)
+    }
+  })
+}
+
+// ============================================================
 // Model reconstruction from ModelDescriptor
 // ============================================================
 
@@ -293,6 +350,7 @@ function trustSystemCertificates(): void {
 }
 
 async function main(): Promise<void> {
+  installCrashGuards()
   trustSystemCertificates()
   const controller = new AbortController()
 

--- a/packages/cyberstrike/src/hackbrowser-subprocess/hackbrowser-worker.ts
+++ b/packages/cyberstrike/src/hackbrowser-subprocess/hackbrowser-worker.ts
@@ -15,6 +15,7 @@
 import { createAnthropic } from "@ai-sdk/anthropic"
 import type { LanguageModel } from "ai"
 import { BUNDLED_PROVIDERS } from "../provider/bundled-providers"
+import { exchangeCopilotToken, invalidateCopilotToken, copilotApiBase, copilotHeaders } from "../provider/copilot-session"
 import { runCrawl } from "@cyberstrike-io/hackbrowser/api"
 import type { CrawlOptions, LogRecord, CSEvent } from "@cyberstrike-io/hackbrowser/api"
 import type { ParentMessage, WorkerMessage, WorkerOptions, ModelDescriptor } from "./worker-ipc"
@@ -139,32 +140,38 @@ function createModelFromDescriptor(desc: ModelDescriptor): LanguageModel {
     return createAnthropic(opts as Parameters<typeof createAnthropic>[0])(desc.modelApiId)
   }
 
-  // GitHub Copilot OAuth: same pattern as Anthropic above.
-  // Swap default auth for Bearer token and add Copilot-specific headers.
+  // GitHub Copilot OAuth: same pattern as Anthropic above, but the raw ghu_
+  // token is NOT accepted by api.githubcopilot.com (403 "Forbidden"). Exchange
+  // it for a short-lived Copilot session token and send the integration/editor
+  // headers Copilot validates. Shared with the main chat provider via
+  // copilot-session.ts so the two can't drift again (#107).
   if (desc.npm.includes("github-copilot") && desc.copilotToken) {
-    const token = desc.copilotToken
+    const githubToken = desc.copilotToken
+    const exchangeBase = copilotApiBase(desc.copilotEnterpriseDomain)
     const factory = BUNDLED_PROVIDERS[desc.npm]
     if (!factory) throw new Error(`hackbrowser: missing bundled provider "${desc.npm}"`)
     const opts: Record<string, unknown> = {
       apiKey: "placeholder",
-      fetch: (url: any, init?: any) => {
-        const headers = new Headers(init?.headers)
-        headers.delete("x-api-key")
-        headers.delete("authorization")
-        headers.set("Authorization", `Bearer ${token}`)
-        headers.set("x-initiator", "user")
-        // CYBERSTRIKE_VERSION is a build-time define that the standalone worker bundle does not
-        // inject, so referencing it bare throws ReferenceError here (in the subprocess) and every
-        // planner call fails → the crawl "completes" with no plan. Guard it exactly like
-        // Installation.VERSION does (installation/index.ts) so it falls back to "local" instead.
-        const version = typeof CYBERSTRIKE_VERSION === "string" ? CYBERSTRIKE_VERSION : "local"
-        headers.set("User-Agent", `cyberstrike/${version}`)
-        headers.set("Openai-Intent", "conversation-edits")
-        return fetch(url, {
-          ...init,
-          headers,
-          body: stripSampling ? stripSamplingParams(init?.body) : init?.body,
-        })
+      fetch: async (url: any, init?: any) => {
+        const body = stripSampling ? stripSamplingParams(init?.body) : init?.body
+        const send = (sessionToken: string) => {
+          const headers = new Headers(init?.headers)
+          headers.delete("x-api-key")
+          headers.delete("authorization")
+          headers.set("x-initiator", "user")
+          for (const [key, value] of Object.entries(copilotHeaders(sessionToken))) headers.set(key, value)
+          return fetch(url, { ...init, headers, body })
+        }
+
+        let response = await send(await exchangeCopilotToken(githubToken, exchangeBase))
+        // A 403 under heavy use is usually a rotated/expired session token, not a
+        // real auth failure. Force a fresh exchange and retry once before the
+        // error surfaces as a stalled crawl.
+        if (response.status === 403) {
+          invalidateCopilotToken(githubToken)
+          response = await send(await exchangeCopilotToken(githubToken, exchangeBase))
+        }
+        return response
       },
     }
     if (desc.baseURL) opts.baseURL = desc.baseURL

--- a/packages/cyberstrike/src/hackbrowser-subprocess/worker-ipc.ts
+++ b/packages/cyberstrike/src/hackbrowser-subprocess/worker-ipc.ts
@@ -34,10 +34,14 @@ export interface ModelDescriptor {
   // process does in-process (anthropic-subscription-model omits them;
   // ProviderTransform.temperature returns undefined for such models).
   supportsTemperature?: boolean
-  // GitHub Copilot OAuth bearer token. When set, the worker authenticates
-  // via Authorization: Bearer instead of apiKey, and adds Copilot-specific
-  // headers (Openai-Intent, x-initiator, User-Agent).
+  // GitHub OAuth token (ghu_…) for Copilot. When set, the worker EXCHANGES it
+  // for a short-lived Copilot session token (copilot-session.ts) and adds the
+  // integration/editor headers Copilot validates. The raw token is not accepted
+  // by api.githubcopilot.com directly (403) — see #107.
   copilotToken?: string
+  // GHE domain (e.g. "company.ghe.com") when the Copilot auth is enterprise, so
+  // the worker exchanges the token at api.{domain} instead of api.github.com.
+  copilotEnterpriseDomain?: string
 }
 
 // ============================================================

--- a/packages/cyberstrike/src/plugin/copilot.ts
+++ b/packages/cyberstrike/src/plugin/copilot.ts
@@ -1,49 +1,10 @@
 import type { Hooks, PluginInput } from "@cyberstrike-io/plugin"
 import { Installation } from "@/installation"
 import { iife } from "@/util/iife"
+import { exchangeCopilotToken, invalidateCopilotToken, copilotApiBase, copilotHeaders } from "@/provider/copilot-session"
 
 const CLIENT_ID = "Iv1.b507a08c87ecfe98"
 
-// GitHub Copilot's chat API validates that requests look like they come from
-// the VS Code Copilot client. These match a recent Copilot Chat build; the
-// exact minor version is not strict but the shape (vscode/… + copilot-chat/…)
-// is. Sourced from the reference copilot-api proxy implementation.
-const COPILOT_EDITOR_VERSION = "vscode/1.99.3"
-const COPILOT_PLUGIN_VERSION = "copilot-chat/0.26.7"
-const COPILOT_USER_AGENT = "GitHubCopilotChat/0.26.7"
-const COPILOT_INTEGRATION_ID = "vscode-chat"
-const COPILOT_API_VERSION = "2025-04-01"
-
-// The GitHub OAuth token (ghu_…) is NOT accepted directly by
-// api.githubcopilot.com — it must first be exchanged for a short-lived
-// Copilot session token (~30 min) at copilot_internal/v2/token. Cache the
-// session token per GitHub token and refresh before it expires.
-const copilotTokenCache = new Map<string, { token: string; expires: number }>()
-
-async function exchangeCopilotToken(githubToken: string, apiBase: string): Promise<string> {
-  const cached = copilotTokenCache.get(githubToken)
-  if (cached && cached.expires > Date.now() + 60_000) return cached.token
-
-  const response = await fetch(`${apiBase}/copilot_internal/v2/token`, {
-    headers: {
-      Authorization: `token ${githubToken}`,
-      "Editor-Version": COPILOT_EDITOR_VERSION,
-      "Editor-Plugin-Version": COPILOT_PLUGIN_VERSION,
-      "User-Agent": COPILOT_USER_AGENT,
-      "X-GitHub-Api-Version": COPILOT_API_VERSION,
-      Accept: "application/json",
-    },
-  })
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => "")
-    throw new Error(`Copilot token exchange failed: ${response.status} ${body.slice(0, 300)}`)
-  }
-
-  const data = (await response.json()) as { token: string; expires_at: number; refresh_in?: number }
-  copilotTokenCache.set(githubToken, { token: data.token, expires: data.expires_at * 1000 })
-  return data.token
-}
 // Add a small safety buffer when polling to avoid hitting the server
 // slightly too early due to clock skew / timer drift.
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000 // 3 seconds
@@ -162,23 +123,14 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             // Exchange the GitHub OAuth token for a short-lived Copilot session
             // token. api.githubcopilot.com rejects the raw ghu_ token (403),
             // which surfaced as constant "reauthenticate" prompts.
-            const exchangeBase = enterpriseUrl ? `https://api.${normalizeDomain(enterpriseUrl)}` : "https://api.github.com"
+            const exchangeBase = copilotApiBase(enterpriseUrl)
 
             const send = (sessionToken: string) => {
               const headers: Record<string, string> = {
                 "x-initiator": isAgent ? "agent" : "user",
                 ...(init?.headers as Record<string, string>),
-                Authorization: `Bearer ${sessionToken}`,
-                // Copilot validates these integration/editor headers — without
-                // them (esp. copilot-integration-id) the API returns 403.
-                "Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
-                "Editor-Version": COPILOT_EDITOR_VERSION,
-                "Editor-Plugin-Version": COPILOT_PLUGIN_VERSION,
-                "User-Agent": COPILOT_USER_AGENT,
-                "X-GitHub-Api-Version": COPILOT_API_VERSION,
-                "Openai-Intent": "conversation-edits",
+                ...copilotHeaders(sessionToken, { vision: isVision }),
               }
-              if (isVision) headers["Copilot-Vision-Request"] = "true"
               delete headers["x-api-key"]
               delete headers["authorization"]
               return fetch(request, { ...init, headers })
@@ -191,7 +143,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             // before the error surfaces as a "reauthenticate" prompt. If the retry
             // still 403s, it's a genuine auth problem and flows through as before.
             if (response.status === 403) {
-              copilotTokenCache.delete(info.refresh)
+              invalidateCopilotToken(info.refresh)
               response = await send(await exchangeCopilotToken(info.refresh, exchangeBase))
             }
 

--- a/packages/cyberstrike/src/provider/copilot-session.ts
+++ b/packages/cyberstrike/src/provider/copilot-session.ts
@@ -1,0 +1,73 @@
+// Shared GitHub Copilot session-token logic, used by BOTH the main chat
+// provider (plugin/copilot.ts) and the hackbrowser crawler worker
+// (hackbrowser-subprocess/hackbrowser-worker.ts). One implementation so the
+// two can't drift — see #107, where the worker carried an unfixed copy and
+// crawls with a Copilot model 403'd ("Forbidden").
+//
+// Dependency-light on purpose (only global fetch): the worker bundles it.
+
+// GitHub Copilot's API validates that requests look like the VS Code Copilot
+// client. Values sourced from the reference copilot-api proxy implementation.
+export const COPILOT_EDITOR_VERSION = "vscode/1.99.3"
+export const COPILOT_PLUGIN_VERSION = "copilot-chat/0.26.7"
+export const COPILOT_USER_AGENT = "GitHubCopilotChat/0.26.7"
+export const COPILOT_INTEGRATION_ID = "vscode-chat"
+export const COPILOT_API_VERSION = "2025-04-01"
+
+// The GitHub OAuth token (ghu_…) is NOT accepted directly by
+// api.githubcopilot.com — exchange it for a short-lived Copilot session token
+// (~30 min) at copilot_internal/v2/token. Cache per GitHub token, refresh
+// before expiry.
+const cache = new Map<string, { token: string; expires: number }>()
+
+export async function exchangeCopilotToken(githubToken: string, apiBase = "https://api.github.com"): Promise<string> {
+  const cached = cache.get(githubToken)
+  if (cached && cached.expires > Date.now() + 60_000) return cached.token
+
+  const response = await fetch(`${apiBase}/copilot_internal/v2/token`, {
+    headers: {
+      Authorization: `token ${githubToken}`,
+      "Editor-Version": COPILOT_EDITOR_VERSION,
+      "Editor-Plugin-Version": COPILOT_PLUGIN_VERSION,
+      "User-Agent": COPILOT_USER_AGENT,
+      "X-GitHub-Api-Version": COPILOT_API_VERSION,
+      Accept: "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    throw new Error(`Copilot token exchange failed: ${response.status} ${body.slice(0, 300)}`)
+  }
+
+  const data = (await response.json()) as { token: string; expires_at: number; refresh_in?: number }
+  cache.set(githubToken, { token: data.token, expires: data.expires_at * 1000 })
+  return data.token
+}
+
+/** Drop the cached session token so the next call re-exchanges (used on 403 retry). */
+export function invalidateCopilotToken(githubToken: string): void {
+  cache.delete(githubToken)
+}
+
+/** Compute the copilot_internal token-exchange base for a domain ("" / github.com → api.github.com). */
+export function copilotApiBase(enterpriseDomain?: string): string {
+  const d = enterpriseDomain?.replace(/^https?:\/\//, "").replace(/\/$/, "")
+  return d && d !== "github.com" ? `https://api.${d}` : "https://api.github.com"
+}
+
+// The integration/editor headers Copilot validates on api.githubcopilot.com
+// requests. Without them (esp. copilot-integration-id) the API returns 403.
+export function copilotHeaders(sessionToken: string, opts?: { vision?: boolean }): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${sessionToken}`,
+    "Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
+    "Editor-Version": COPILOT_EDITOR_VERSION,
+    "Editor-Plugin-Version": COPILOT_PLUGIN_VERSION,
+    "User-Agent": COPILOT_USER_AGENT,
+    "X-GitHub-Api-Version": COPILOT_API_VERSION,
+    "Openai-Intent": "conversation-edits",
+  }
+  if (opts?.vision) headers["Copilot-Vision-Request"] = "true"
+  return headers
+}

--- a/packages/cyberstrike/src/provider/error.ts
+++ b/packages/cyberstrike/src/provider/error.ts
@@ -27,6 +27,21 @@ export namespace ProviderError {
     /context[_ ]length[_ ]exceeded/i, // Generic fallback
   ]
 
+  // Provider-side content moderation that rejects security/offensive prompts
+  // ("possible cybersecurity risk"). This is OpenAI's cyber filter — it also
+  // fires on OpenAI models proxied through GitHub Copilot. CyberStrike cannot
+  // disable it; detecting it lets us surface actionable guidance instead of a
+  // raw crash, and mark it non-retryable so it doesn't retry-spam. See #111.
+  const CONTENT_FILTER_PATTERNS = [
+    /flagged for possible cybersecurity risk/i,
+    /flagged as a potential (?:security|cybersecurity) risk/i,
+    /Trusted Access for Cyber/i,
+  ]
+
+  function isContentFilter(message: string) {
+    return CONTENT_FILTER_PATTERNS.some((p) => p.test(message))
+  }
+
   function isServerError(status?: number) {
     return !!status && status >= 500
   }
@@ -196,6 +211,23 @@ export namespace ProviderError {
         type: "context_overflow",
         message: m,
         responseBody: input.error.responseBody,
+      }
+    }
+
+    if (isContentFilter(m)) {
+      return {
+        type: "api_error",
+        message:
+          "Blocked by the AI provider's cybersecurity content filter. This is a server-side policy on the model provider " +
+          "(it also applies to OpenAI models proxied through GitHub Copilot) and cannot be disabled by CyberStrike. " +
+          "For offensive-security work, set your default model to an API-key provider such as Anthropic or OpenAI direct. " +
+          `Provider detail: ${m}`,
+        statusCode: input.error.statusCode,
+        // Same prompt will be blocked every time — retrying just wastes calls.
+        isRetryable: false,
+        responseHeaders: input.error.responseHeaders,
+        responseBody: input.error.responseBody,
+        metadata: input.error.url ? { url: input.error.url } : undefined,
       }
     }
 

--- a/packages/cyberstrike/src/provider/provider.ts
+++ b/packages/cyberstrike/src/provider/provider.ts
@@ -1247,6 +1247,7 @@ export namespace Provider {
     anthropicUserId?: string
     anthropicSystemPrefix?: string
     copilotToken?: string
+    copilotEnterpriseDomain?: string
   }> {
     const s = await state()
     const provider = s.providers[model.providerID]
@@ -1296,13 +1297,15 @@ export namespace Provider {
       if (auth?.type === "oauth" && auth.refresh) {
         // Enterprise deployments route through copilot-api.{domain}
         let baseURL = options["baseURL"] as string | undefined
+        let enterpriseDomain: string | undefined
         if (auth.enterpriseUrl) {
-          const domain = auth.enterpriseUrl.replace(/^https?:\/\//, "").replace(/\/$/, "")
-          baseURL = `https://copilot-api.${domain}`
+          enterpriseDomain = auth.enterpriseUrl.replace(/^https?:\/\//, "").replace(/\/$/, "")
+          baseURL = `https://copilot-api.${enterpriseDomain}`
         }
         return {
           npm: model.api.npm,
           copilotToken: auth.refresh,
+          copilotEnterpriseDomain: enterpriseDomain,
           baseURL,
           modelApiId: model.api.id,
           headers: mergedHeaders,

--- a/packages/cyberstrike/src/server/routes/session.ts
+++ b/packages/cyberstrike/src/server/routes/session.ts
@@ -1510,7 +1510,8 @@ export const SessionRoutes = lazy(() =>
         }),
       ),
       async (c) => {
-        SessionPrompt.cancel(c.req.valid("param").sessionID)
+        // Genuine user abort (Esc) — stop the background hackbrowser crawl too.
+        SessionPrompt.cancel(c.req.valid("param").sessionID, { stopCrawl: true })
         return c.json(true)
       },
     )

--- a/packages/cyberstrike/src/session/index.ts
+++ b/packages/cyberstrike/src/session/index.ts
@@ -616,6 +616,13 @@ export namespace Session {
   export const remove = fn(Identifier.schema("session"), async (sessionID) => {
     const project = Instance.project
     try {
+      // Deleting a session is a genuine teardown — stop any background
+      // hackbrowser crawl it launched (turn-end no longer does this). Dynamic
+      // import avoids a session ↔ launcher import cycle; no-op if no active run.
+      const { stopHackbrowser } = await import("@/tool/hackbrowser-launcher")
+      try {
+        stopHackbrowser(sessionID)
+      } catch {}
       const session = await get(sessionID)
       for (const child of await children(sessionID)) {
         await remove(child.id)

--- a/packages/cyberstrike/src/session/prompt.ts
+++ b/packages/cyberstrike/src/session/prompt.ts
@@ -265,11 +265,20 @@ export namespace SessionPrompt {
     return s[sessionID].abort.signal
   }
 
-  export function cancel(sessionID: string) {
-    log.info("cancel", { sessionID })
-    try {
-      stopHackbrowser(sessionID)
-    } catch {}
+  // stopCrawl defaults to FALSE: a bare cancel() is the loop/prompt turn-end
+  // cleanup (fired by the two defer()s below and by child-session teardown),
+  // and a background hackbrowser crawl must SURVIVE those turn boundaries so it
+  // can run to its own maxPages / empty queue. Only a genuine teardown — the
+  // user pressing Esc (/abort route) or the session being deleted — passes
+  // stopCrawl:true. Previously this always stopped the crawl, so every turn end
+  // killed the crawl after ~3 pages (see hackbrowser crawl-lifetime fix).
+  export function cancel(sessionID: string, opts?: { stopCrawl?: boolean }) {
+    log.info("cancel", { sessionID, stopCrawl: opts?.stopCrawl ?? false })
+    if (opts?.stopCrawl) {
+      try {
+        stopHackbrowser(sessionID)
+      } catch {}
+    }
     const s = state()
     const match = s[sessionID]
     if (!match) {

--- a/packages/cyberstrike/src/tool/hackbrowser-launcher.ts
+++ b/packages/cyberstrike/src/tool/hackbrowser-launcher.ts
@@ -150,8 +150,9 @@ async function prepareCrawl(opts: LauncherOptions): Promise<PreparedWorker> {
   // here so the error surfaces as a clean message instead.
   // Bun.resolve mirrors the worker's actual module lookup (upward traversal
   // from bin/ + NODE_PATH), so no false positives on non-standard installs.
+  let playwrightEntry: string
   try {
-    await Bun.resolve("playwright", Global.Path.bin)
+    playwrightEntry = await Bun.resolve("playwright", Global.Path.bin)
   } catch {
     throw new Error(
       `playwright is not installed. Run:\n` +
@@ -163,7 +164,11 @@ async function prepareCrawl(opts: LauncherOptions): Promise<PreparedWorker> {
   // 2c. Verify Chromium binary is installed. If missing, attempt automatic
   // installation via `npx playwright install chromium`. This avoids the common
   // UX issue where users install cyberstrike but don't know they need Chromium.
-  const playwrightDir = path.join(Global.Path.data, "node_modules", "playwright")
+  // Derive the playwright package dir from the RESOLVED entry (2b), not a
+  // hardcoded Global.Path.data path — with hoisted/non-standard installs the
+  // package lives elsewhere and the old assumption produced "Module not found
+  // .../node_modules/playwright/cli.js" while chromium was actually present.
+  const playwrightDir = path.dirname(playwrightEntry)
   try {
     const { execSync } = await import("child_process")
     const fullScript = `process.stdout.write(require(${JSON.stringify(playwrightDir.replace(/\\/g, "/"))}).chromium.executablePath())`

--- a/packages/cyberstrike/src/tool/hackbrowser.ts
+++ b/packages/cyberstrike/src/tool/hackbrowser.ts
@@ -81,7 +81,11 @@ export const HackbrowserTool = Tool.define("hackbrowser", {
       credentials: args.credentials,
       steps: args.steps,
       headless: args.headless,
-      signal: ctx.abort,
+      // Intentionally NOT passing signal: ctx.abort. ctx.abort is the agent
+      // TURN's abort — it fires on every normal turn-end (cancel → match.abort),
+      // which would forward an abort to the worker and kill the still-running
+      // background crawl. The crawl is stopped only via stopHackbrowser (Esc /
+      // session-delete / /hackbrowser-stop), never the turn lifecycle.
     })
 
     // Output is intentionally a "started" notice, NOT a result summary.

--- a/packages/hackbrowser/src/agent.ts
+++ b/packages/hackbrowser/src/agent.ts
@@ -476,7 +476,17 @@ function setupRequestInterceptor(
     }
 
     const method = request.method()
-    const headers = await request.allHeaders()
+    let headers: Record<string, string>
+    try {
+      headers = await request.allHeaders()
+    } catch {
+      // Target/page/browser closed mid-flight — in headed mode this fires when
+      // the crawl ends or the user closes the window while requests are still
+      // in flight. This is a fire-and-forget capture handler, so a rejected
+      // allHeaders() here would become an unhandled rejection and crash the
+      // worker (exit 1). Drop the capture instead.
+      return
+    }
     const postData = request.postData() ?? null
     const raw = buildRawRequest(method, url, headers, postData)
 

--- a/packages/hackbrowser/src/agent.ts
+++ b/packages/hackbrowser/src/agent.ts
@@ -555,6 +555,13 @@ function setupRequestInterceptor(
   return {
     setPendingUI: (promise) => {
       pendingUIContext = promise
+      // Detached no-op catch: the consumer awaits this promise inside its own
+      // try/catch, but ONLY on mutating requests — on a GET (or if overwritten
+      // first) a rejection from snapshotPageUI would otherwise go unhandled and
+      // crash the whole worker (this was the #116 crash path). Marking it
+      // handled here changes nothing for the consumer (it awaits `promise`),
+      // it only prevents the process-killing unhandled rejection. See #117.
+      promise.catch(() => {})
     },
     setPendingTrigger: (trigger) => {
       pendingTrigger = trigger

--- a/packages/hackbrowser/src/agent.ts
+++ b/packages/hackbrowser/src/agent.ts
@@ -28,7 +28,7 @@ import {
   initAuth,
 } from "./ingest.ts"
 import { loadSession, autoLogin, handle2FA, waitForManualLogin } from "./auth.ts"
-import { resolveModel, planPage, planUnexploredElements } from "./navigator.ts"
+import { resolveModel, planPage, planUnexploredElements, isAuthError } from "./navigator.ts"
 import {
   collectElements,
   isViewportCenterBlocked,
@@ -2211,6 +2211,11 @@ async function runMultiCredential(config: AgentConfig, credentials: CredentialCo
           })
           break
         }
+        // Auth/credential failures (401/403, missing key) never recover within a
+        // run. Swallowing them here let the crawl finish as a clean "complete"
+        // with zero captures (#107). Propagate so runCrawl records the error and
+        // the launcher marks the run "failed".
+        if (isAuthError(err)) throw err
         log.warn("exploration error", { credential: ctx.id, url: entry.url, err: String(err) })
       }
     }
@@ -2644,6 +2649,8 @@ export async function run(config: AgentConfig): Promise<CrawlResult> {
           log.error("exploration aborted — browser died mid-page", { url: currentUrl, reason: health.reason })
           break
         }
+        // See note above: auth failures must fail the crawl, not complete it (#107).
+        if (isAuthError(err)) throw err
         log.warn("exploration error", { url: currentUrl, err: String(err) })
       }
 

--- a/packages/hackbrowser/src/agent.ts
+++ b/packages/hackbrowser/src/agent.ts
@@ -65,6 +65,29 @@ import type { RawElement } from "./types.ts"
 
 const log = Log.create({ service: "hackbrowser:agent" })
 
+// ── Env-gated fault injector (test-only, #117) ─────────────────────────────
+// Deliberately triggers a worker-level fault so the crash safety net can be
+// verified end-to-end. NO effect unless CYBERSTRIKE_HB_FAULT is set. Fires once
+// mid-crawl (default page 3, override via CYBERSTRIKE_HB_FAULT_AT) so you can
+// confirm the crawl CONTINUES past the fault instead of the worker dying.
+//   CYBERSTRIKE_HB_FAULT=unhandled → an un-awaited Promise.reject (mimics #116)
+//   CYBERSTRIKE_HB_FAULT=uncaught  → a sync throw in a timer callback
+let faultInjected = false
+function maybeInjectFault(pagesExplored: number): void {
+  const fault = process.env.CYBERSTRIKE_HB_FAULT
+  if (!fault || faultInjected) return
+  if (pagesExplored < Number(process.env.CYBERSTRIKE_HB_FAULT_AT ?? "3")) return
+  faultInjected = true
+  log.warn("injecting TEST fault (CYBERSTRIKE_HB_FAULT)", { fault, pagesExplored })
+  if (fault === "unhandled") {
+    void Promise.reject(new Error(`injected fault: unhandledRejection at page ${pagesExplored}`))
+  } else if (fault === "uncaught") {
+    setTimeout(() => {
+      throw new Error(`injected fault: uncaughtException at page ${pagesExplored}`)
+    }, 0)
+  }
+}
+
 // ============================================================
 // Constants
 // ============================================================
@@ -2053,6 +2076,7 @@ async function runMultiCredential(config: AgentConfig, credentials: CredentialCo
 
     const entry = pageQueue.shift()!
     pagesExplored++
+    maybeInjectFault(pagesExplored)
 
     log.info("processing URL", {
       page: `${pagesExplored}/${maxPages}`,
@@ -2514,6 +2538,7 @@ export async function run(config: AgentConfig): Promise<CrawlResult> {
 
       const nextUrl = globalState.pageQueue.shift()!
       pagesExplored++
+      maybeInjectFault(pagesExplored)
 
       if (page.url() !== nextUrl) {
         const navErr = await page

--- a/packages/hackbrowser/src/capture.ts
+++ b/packages/hackbrowser/src/capture.ts
@@ -43,8 +43,12 @@ export async function snapshotPageUI(page: Page, trigger: Locator | null, compon
 
         const id = el.getAttribute("id")
         if (id) {
-          const label = document.querySelector(`label[for="${id}"]`)
-          if (label) return label.textContent?.trim() ?? ""
+          // Escape + guard: an unescaped id with a special char builds an invalid
+          // selector and throws inside page.evaluate, crashing the worker (#116).
+          try {
+            const label = document.querySelector(`label[for="${CSS.escape(id)}"]`)
+            if (label) return label.textContent?.trim() ?? ""
+          } catch {}
         }
 
         const parentLabel = el.closest("label")

--- a/packages/hackbrowser/src/navigator.ts
+++ b/packages/hackbrowser/src/navigator.ts
@@ -22,7 +22,7 @@ const log = Log.create({ service: "hackbrowser:navigator" })
  * Rethrowing lets runCrawl record the error in CrawlResult.errors[], which the
  * launcher surfaces as a "failed" phase. Transient errors keep the fallback.
  */
-function isAuthError(err: unknown): boolean {
+export function isAuthError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false
   const e = err as { name?: string; statusCode?: number; lastError?: unknown; errors?: unknown[] }
   if (e.name === "AI_LoadAPIKeyError") return true

--- a/packages/hackbrowser/src/scanner.ts
+++ b/packages/hackbrowser/src/scanner.ts
@@ -126,8 +126,13 @@ async function collectInteractiveElements(page: Page): Promise<BrowserElement[]>
       }
       const id = el.getAttribute("id")
       if (id) {
-        const labelEl = document.querySelector(`label[for="${id}"]`)
-        if (labelEl?.textContent?.trim()) return labelEl.textContent.trim()
+        // CSS.escape + try/catch: an id with a quote/special char would otherwise
+        // build an invalid selector (e.g. label[for="content""]) and throw a
+        // SyntaxError that crashes the whole worker mid-crawl (#116).
+        try {
+          const labelEl = document.querySelector(`label[for="${CSS.escape(id)}"]`)
+          if (labelEl?.textContent?.trim()) return labelEl.textContent.trim()
+        } catch {}
       }
       const text = (el as HTMLElement).innerText?.trim()
       if (text && text.length < 80) return text

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -25,6 +25,7 @@ const env = {
 const CHANNEL = await (async () => {
   if (env.CYBERSTRIKE_CHANNEL) return env.CYBERSTRIKE_CHANNEL
   if (env.CYBERSTRIKE_BUMP === "beta") return "beta"
+  if (env.CYBERSTRIKE_BUMP === "canary") return "canary"
   if (env.CYBERSTRIKE_BUMP) return "latest"
   if (env.CYBERSTRIKE_VERSION && !env.CYBERSTRIKE_VERSION.startsWith("0.0.0-")) {
     // Extract prerelease tag from semver (e.g. "1.1.6-beta.1" → "beta")
@@ -37,7 +38,7 @@ const IS_PREVIEW = CHANNEL !== "latest"
 
 const VERSION = await (async () => {
   if (env.CYBERSTRIKE_VERSION) return env.CYBERSTRIKE_VERSION
-  if (IS_PREVIEW && env.CYBERSTRIKE_BUMP !== "beta")
+  if (IS_PREVIEW && env.CYBERSTRIKE_BUMP !== "beta" && env.CYBERSTRIKE_BUMP !== "canary")
     return `0.0.0-${CHANNEL}-${new Date().toISOString().slice(0, 16).replace(/[-:T]/g, "")}`
 
   const registry = (await fetch("https://registry.npmjs.org/@cyberstrike-io%2Fcyberstrike").then((res) => {
@@ -45,25 +46,26 @@ const VERSION = await (async () => {
     return res.json()
   })) as { "dist-tags": Record<string, string>; versions: Record<string, unknown> }
 
-  if (env.CYBERSTRIKE_BUMP === "beta") {
+  if (env.CYBERSTRIKE_BUMP === "beta" || env.CYBERSTRIKE_BUMP === "canary") {
+    const pre = env.CYBERSTRIKE_BUMP // "beta" | "canary" — separate dist-tags, separate counters
     const latest = registry["dist-tags"]?.latest
     if (!latest) throw new Error("No published latest version found on npm")
     const [major, minor, patch] = latest.split(".").map((x: string) => Number(x) || 0)
 
-    const beta = registry["dist-tags"]?.beta
-    if (beta) {
-      const betaMatch = beta.match(/^(\d+)\.(\d+)\.(\d+)-beta\.(\d+)$/)
-      if (betaMatch) {
-        const [, bMaj, bMin, bPatch, bNum] = betaMatch
+    const current = registry["dist-tags"]?.[pre]
+    if (current) {
+      const m = current.match(new RegExp(`^(\\d+)\\.(\\d+)\\.(\\d+)-${pre}\\.(\\d+)$`))
+      if (m) {
+        const [, bMaj, bMin, bPatch, bNum] = m
         const sameMajor = Number(bMaj) === major
         const sameMinor = Number(bMin) === minor
         const samePatch = Number(bPatch) === patch + 1
         if (sameMajor && sameMinor && samePatch) {
-          return `${bMaj}.${bMin}.${bPatch}-beta.${Number(bNum) + 1}`
+          return `${bMaj}.${bMin}.${bPatch}-${pre}.${Number(bNum) + 1}`
         }
       }
     }
-    return `${major}.${minor}.${patch + 1}-beta.0`
+    return `${major}.${minor}.${patch + 1}-${pre}.0`
   }
 
   const version = registry["dist-tags"]?.latest


### PR DESCRIPTION
Syncs `main` with `stage` — 17 commits of hackbrowser reliability fixes, a provider content-filter improvement, and release-channel tooling. Verified across Anthropic-direct and GitHub Copilot (Opus 4.8 + gpt-5.6-luna); shipped/tested via the canary channel (canary.6) except GAP A, which is stage-only and mechanism-verified.

## HackBrowser crash & lifetime (the core)

- **Crawl killed at every turn-end** → runs to its own maxPages / drains its queue now (#115). `cancel(stopCrawl)` gate + drop `signal: ctx.abort` + stop on session delete.
- **Selector crash** — an unescaped id in `label[for]` threw in page.evaluate and killed the whole worker; escape + guard so one bad element can't abort a crawl (#116).
- **Worker crash safety net (GAP A)** — global `unhandledRejection`/`uncaughtException` handlers (log + continue, circuit breaker) + un-awaited pendingUI guard, so no single throw kills the crawl. Env-gated fault injector for on-demand testing (#117).
- **`request.allHeaders()` guard** — a closed target can no longer crash the worker (#104).
- **Fail crawl on auth errors** instead of silently "completing" with zero captures.

## Copilot / provider

- **Copilot worker token exchange** (#107) — shared `copilot-session.ts` used by both the chat provider and the crawler worker (exchange + integration headers + retry-403 + enterprise domain). Full crawls verified on Copilot Opus 4.8 and luna.
- **Content-filter errors** surface as clear, non-retryable guidance instead of a raw crash (#111).
- **Chromium check** resolves the real playwright dir instead of a hardcoded path.

## Release tooling

- **Canary channel** for throwaway test builds (npm `@canary`).
- **`platform=all`** build fix (GH Actions ternary + build-OS filter).

## Housekeeping

- Ignore all `cookies*.txt` dumps.

Merge is clean (no conflicts). `main` also keeps its own `ignore: update download stats` commit.
