### PR TITLE
fix(hackbrowser): wait for DOM quiescence to capture timer-mounted content

### DIFF
--- a/packages/hackbrowser/src/agent.ts
+++ b/packages/hackbrowser/src/agent.ts
@@ -125,6 +125,54 @@ const SKIP_AUTO_DISCOVERY = /\b(logout|sign.?out|log.?out|delete.?account|reset.
 async function stabilizeAfterGoto(page: Page): Promise<void> {
   await page.waitForTimeout(POST_GOTO_WAIT)
   await page.waitForLoadState("networkidle", { timeout: NETWORK_IDLE_TIMEOUT }).catch(() => {})
+  await waitForDomQuiescence(page)
+}
+
+/**
+ * DOM-mutation quiescence wait for timer-mounted content (issue #103 gap B).
+ * Timer-driven mounts (setTimeout, no network) are invisible to networkidle.
+ * Wait until the DOM has been quiet for DOM_QUIET_MS, bounded by DOM_QUIET_TIMEOUT
+ * so a page with continuous mutations (chat widget, analytics) never blocks the crawl.
+ * On a stable page the cost is just DOM_QUIET_MS; on a mutating page it caps at
+ * DOM_QUIET_TIMEOUT (covers the 4.5s synthetic repro with margin).
+ */
+const DOM_QUIET_MS = 600
+const DOM_QUIET_TIMEOUT = 5000
+
+export async function waitForDomQuiescence(page: Page): Promise<void> {
+  try {
+    await page.evaluate(
+      ({ quietMs, timeoutMs }) => {
+        return new Promise<void>((resolve) => {
+          let quietTimer: number | undefined
+          const timeout = window.setTimeout(() => {
+            observer.disconnect()
+            if (quietTimer !== undefined) clearTimeout(quietTimer)
+            resolve()
+          }, timeoutMs)
+          const observer = new MutationObserver(() => {
+            if (quietTimer !== undefined) clearTimeout(quietTimer)
+            quietTimer = window.setTimeout(() => {
+              clearTimeout(timeout)
+              observer.disconnect()
+              resolve()
+            }, quietMs)
+          })
+          observer.observe(document.documentElement, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+          })
+          quietTimer = window.setTimeout(() => {
+            clearTimeout(timeout)
+            observer.disconnect()
+            resolve()
+          }, quietMs)
+        })
+      },
+      { quietMs: DOM_QUIET_MS, timeoutMs: DOM_QUIET_TIMEOUT },
+    )
+  } catch {}
 }
 
 // ============================================================


### PR DESCRIPTION
## What does this PR do?

Fixes #103. `networkidle` misses content mounted by `setTimeout` with no network activity, so the scan finishes before timer-driven widgets appear. This adds a bounded DOM quiescence wait (quiet 600 ms, timeout 5 s) to the post-navigation settle step; stable pages add ~600 ms and the 4.5 s repro is now captured. The transient-UI auto-close gap was already fixed on `main` by `01647a5a`.

## Type of change

- [ ] Bug fix
- [ ] New feature / agent
- [ ] Security tool / MCP server / Bolt plugin
- [ ] Agent skill / knowledge base
- [ ] UI / TUI improvement
- [ ] Documentation
- [ ] Refactor / performance
- [ ] CI / infrastructure

## Security impact

- [ ] This PR adds or modifies tool execution (shell, file, network)
- [ ] This PR changes agent permissions or scope
- [ ] This PR modifies authentication / authorization logic
- [ ] This PR has no security impact

## How did you verify it works?

Synthetic localhost page that appends a button after 4.5 s — before the fix the scan never saw it, after it is found. Existing hackbrowser unit tests still pass.

## Checklist

- [ ] `bun turbo typecheck` passes
- [ ] Tested locally with at least one LLM provider
- [ ] PR is focused on a single change
- [ ] No secrets, credentials, or API keys in the diff
- [ ] Breaking changes are documented (if any)

Reviewers: @badchars