### PR TITLE
fix(normalize): cover modern IDs, matrix params, gRPC-Web and tRPC

### DIFF
--- a/packages/cyberstrike/src/session/normalize/parser.ts
+++ b/packages/cyberstrike/src/session/normalize/parser.ts
@@ -45,13 +45,14 @@ export function parseRawRequest({ raw, scheme }: ParseInput): ParsedRequest {
   // for non-JSON, where the value-bearing bodyHash remains the fallback.
   const bodyKeyHash = bodyKeyShapeHash(body, bodyContentType)
 
-  // Body/header-dispatched protocols (GraphQL, JSON-RPC): derive a per-operation
-  // identity so each operation is its own dedup unit. Undefined ⇒ plain REST.
+  // Body/header-dispatched protocols (GraphQL, JSON-RPC, tRPC, gRPC-Web): derive a
+  // per-operation identity so each operation is its own dedup unit. Undefined ⇒ plain REST.
   const op = extractOperation({
     method,
     bodyContentType,
     body,
     query: targetUrl.search.replace(/^\?/, ""),
+    path: canonicalPath,
   })
 
   return {
@@ -109,7 +110,16 @@ function findAuthority(lines: string[]): string | undefined {
 // (%20, %40, ...) are decoded so regex classification works on a clean form.
 function canonicalizePath(path: string): { canonicalPath: string; segments: string[] } {
   const rawSegments = path.split("/")
-  const decoded = rawSegments.map((seg) => safeDecodePreservingSlash(seg).toLowerCase())
+  const decoded = rawSegments.map((seg) => {
+    // Strip matrix params (;-delimited per-segment params like ;jsessionid= or
+    // ;color=red). They are not part of endpoint identity and may leak session tokens.
+    const withoutMatrix = seg.split(";")[0] ?? ""
+    const dec = safeDecodePreservingSlash(withoutMatrix)
+    // Preserve case for opaque case-sensitive ids (base62/nanoid etc) so
+    // differing-case ids do not collapse; otherwise lowercase for normalization.
+    if (isCaseSensitiveId(dec)) return dec
+    return dec.toLowerCase()
+  })
 
   // Strip a single trailing empty segment (from trailing slash); keep the
   // leading empty segment that represents the root.
@@ -120,6 +130,22 @@ function canonicalizePath(path: string): { canonicalPath: string; segments: stri
     canonicalPath: joined === "" ? "/" : joined,
     segments: decoded,
   }
+}
+
+function isCaseSensitiveId(seg: string): boolean {
+  if (seg.includes("%")) return false
+  if (seg.length < 16) return false
+  // TypeID suffix, KSUID, nanoid, cuid, Stripe suffix, base62 mixed-case
+  if (/^[0-9A-HJKMNP-TV-Z]{26}$/i.test(seg)) return false // ULID is case-insensitive (Crockford)
+  if (/^[A-Za-z0-9_-]{21}$/.test(seg)) return true
+  if (/^[0-9A-Za-z]{27}$/.test(seg)) return true
+  if (/^c[a-z0-9]{24,}$/.test(seg)) return false // cuid is lowercase
+  if (/^[a-z]{2,10}_[A-Za-z0-9]{14,}$/.test(seg)) return true
+  if (/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[A-Za-z0-9_-]{16,}$/.test(seg)) return true
+  if (/^[a-z][a-z0-9_]*_[0-9A-HJKMNP-TV-Z]{26}$/i.test(seg)) return true
+  // generic: contains both upper and lower + digit, length >=16
+  if (seg.length >= 16 && /[a-z]/.test(seg) && /[A-Z]/.test(seg) && /[0-9]/.test(seg)) return true
+  return false
 }
 
 // Decode percent-encoding in a segment while keeping %2F encoded. We replace

--- a/packages/cyberstrike/src/session/normalize/protocol.ts
+++ b/packages/cyberstrike/src/session/normalize/protocol.ts
@@ -17,7 +17,7 @@ import { parseXmlToObject } from "./xml"
 import { extractInlineArgPaths } from "./graphql-inline"
 
 export interface OperationInfo {
-  protocol: "graphql" | "jsonrpc"
+  protocol: "graphql" | "jsonrpc" | "trpc" | "grpc-web"
   operation: string // human label, e.g. "mutation:deleteUser", "user.delete"
   opKeyHash: string // 16-char dedup discriminator (values stripped)
 }
@@ -444,6 +444,12 @@ function parseMultipartFields(body: string): BodyField[] {
  * before the parse was unified (guarded by a golden characterization test).
  */
 export function bodyKeyShapeHash(body: string | undefined, contentType: string | undefined): string | undefined {
+  const ct = (contentType ?? "").toLowerCase()
+  // gRPC-Web binary bodies are not JSON-parseable; provide a stable shape hash so
+  // the endpoint does not fragment per body value (fallback would be value-bearing bodyHash).
+  if (ct.includes("grpc-web") || ct.includes("application/grpc")) {
+    return sha16("grpc-web-shape")
+  }
   const parsed = parseBody(body, contentType)
   switch (parsed.kind) {
     case "json": {
@@ -472,13 +478,92 @@ export function bodyKeyShapeHash(body: string | undefined, contentType: string |
  * plain REST (the caller then falls back to body_hash/query_hash dedup).
  * Deterministic, pure — safe for the tier0 parser.
  */
+function trpcFrom(query: string, path: string): OperationInfo | undefined {
+  // tRPC is an operation-over-URL protocol like GraphQL: procedures live in the
+  // path after /trpc/ (comma-separated, batch=1) and inputs in query `input`.
+  // Normalize to per-operation identity so /trpc/a,b?batch=1 does not fragment.
+  const m = path.match(/\/trpc\/([^?]+)/i)
+  if (!m) return undefined
+  const rawProcs = m[1]!
+  const procedures = rawProcs
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .sort()
+  if (procedures.length === 0) return undefined
+  const params = new URLSearchParams(query)
+  const inputRaw = params.get("input")
+  let keyShape: string[] = []
+  if (inputRaw) {
+    try {
+      const parsed = JSON.parse(inputRaw)
+      // tRPC batch wraps under numeric keys: {"0":{"json":{...}}}
+      // Unwrap to get real input shape; values stripped.
+      const toShape = (v: unknown): string[] => {
+        if (!v || typeof v !== "object") return []
+        const obj = v as Record<string, unknown>
+        const numericKeys = Object.keys(obj).filter((k) => /^\d+$/.test(k))
+        if (numericKeys.length > 0) {
+          const merged: Record<string, unknown> = {}
+          for (const k of numericKeys) {
+            const j = (obj[k] as Record<string, unknown> | undefined)?.json
+            if (j && typeof j === "object") Object.assign(merged, j)
+            else if (j) merged[k] = j
+          }
+          return keyPaths(merged).sort()
+        }
+        const j = obj.json
+        if (j && typeof j === "object") return keyPaths(j).sort()
+        return keyPaths(obj).sort()
+      }
+      // For batch, shape is union of per-procedure shapes
+      if (procedures.length > 1) {
+        const perProc = Object.keys(parsed as Record<string, unknown>).sort()
+        const all: string[] = []
+        for (const k of perProc) all.push(...toShape((parsed as Record<string, unknown>)[k]))
+        keyShape = [...new Set(all)].sort()
+      } else {
+        keyShape = toShape(parsed)
+      }
+    } catch {
+      // ignore parse failure
+    }
+  }
+  const label = procedures.length === 1 ? procedures[0]! : `batch[${procedures.join(",")}]`
+  const keyParts = ["trpc", procedures.join(","), keyShape.join(",")]
+  return { protocol: "trpc", operation: label, opKeyHash: sha16(keyParts.join("<|>")) }
+}
+
 export function extractOperation(input: {
   method: string
   bodyContentType?: string
   body?: string
   query?: string // raw URL query string (without leading '?')
+  path?: string // canonical path for tRPC detection
 }): OperationInfo | undefined {
   const ct = input.bodyContentType ?? ""
+  const lowerCt = ct.toLowerCase()
+
+  // tRPC — path-based procedures, query-carried inputs. Check before GraphQL
+  // because tRPC may also have ?input JSON.
+  const pathForTrpc = input.path ?? ""
+  if (pathForTrpc.toLowerCase().includes("/trpc/")) {
+    const trpc = trpcFrom(input.query ?? "", pathForTrpc)
+    if (trpc) return trpc
+  }
+  // Also detect tRPC from query when path not supplied (caller passes only query)
+  if (input.query && input.query.includes("batch=") && pathForTrpc === "") {
+    // opportunistic: if query looks like trpc batch, try generic
+    const maybe = trpcFrom(input.query, "/trpc/" + (new URLSearchParams(input.query).get("trpc") ?? ""))
+    if (maybe) return maybe
+  }
+
+  // gRPC-Web — content-type based, no body JSON. Alias the path as operation so
+  // each service/method is its own endpoint, but body values do not fragment.
+  if (lowerCt.includes("grpc-web") || lowerCt.includes("application/grpc")) {
+    const op = (input.path ?? "").replace(/^\//, "") || "grpc"
+    return { protocol: "grpc-web", operation: op, opKeyHash: sha16("grpc-web<|>" + op) }
+  }
 
   // GraphQL-over-GET: the query lives in the URL, not the body. (queryKeyHash
   // keys on param names only, so without this `?query=A` and `?query=B` would
@@ -487,6 +572,11 @@ export function extractOperation(input: {
     const params = new URLSearchParams(input.query)
     const q = params.get("query")
     if (q && q.includes("{")) return graphqlFrom(q, params.get("variables"))
+    // tRPC GET fallback when extractOperation called without path (parser passes path)
+    if (pathForTrpc.toLowerCase().includes("/trpc/")) {
+      const t = trpcFrom(input.query, pathForTrpc)
+      if (t) return t
+    }
     return undefined
   }
 

--- a/packages/cyberstrike/src/session/normalize/slots.ts
+++ b/packages/cyberstrike/src/session/normalize/slots.ts
@@ -52,8 +52,13 @@ function pathSlots(normalizedPath: string, canonicalPath: string): ParamSlot[] {
   const out: ParamSlot[] = []
   for (let i = 0; i < t.length; i++) {
     const seg = t[i]!
-    if (seg.length > 2 && seg[0] === "{" && seg[seg.length - 1] === "}" && c[i] != null && c[i] !== "") {
-      out.push({ loc: "path", name: seg.slice(1, -1), value: c[i]! })
+    if (seg.includes("{") && seg.includes("}") && c[i] != null && c[i] !== "") {
+      // For partial placeholders like order_{ulid}, extract name inside braces
+      const m = seg.match(/\{([^}]+)\}/)
+      const name = m ? m[1]! : seg.slice(1, -1)
+      // Preserve prefix context for TypeID: order_{ulid} → name "order_{ulid}" keeps prefix
+      const slotName = seg.includes("_{ulid}") ? seg : name
+      out.push({ loc: "path", name: slotName, value: c[i]! })
     }
   }
   return out

--- a/packages/cyberstrike/src/session/normalize/tier1.ts
+++ b/packages/cyberstrike/src/session/normalize/tier1.ts
@@ -22,12 +22,18 @@ const DYNAMIC_PATTERNS: ReadonlyArray<readonly [RegExp, Placeholder, string]> = 
   [/^[0-9a-f]{12,}$/i, "{hash}", "hex hash >=12 chars"],
   // ULID — 26-char Crockford base32 (excludes I/L/O/U). Placed AFTER hex so a
   // 26-char all-hex string keeps {hash}; real ULIDs carry g–z letters and won't
-  // collide. Case-insensitive because segments arrive lowercased. Slotted to the
-  // shared {id} (not a new placeholder) so it is stable regardless of which
-  // provider's Tier-3 would otherwise guess {uuid} vs {id}. Other modern IDs
-  // (KSUID/nanoid/cuid/base62/Stripe/TypeID) use broader, case-sensitive alphabets
-  // with real false-positive risk, so they stay ambiguous for Tier 3.
-  [/^[0-9A-HJKMNP-TV-Z]{26}$/i, "{id}", "ULID (Crockford base32, 26 chars)"],
+  // collide.
+  [/^[0-9A-HJKMNP-TV-Z]{26}$/i, "{ulid}", "ULID (Crockford base32, 26 chars)"],
+  // KSUID — 27-char base62 (0-9A-Za-z). Length + mixed case keeps false positives low.
+  [/^[0-9A-Za-z]{27}$/, "{id}", "KSUID (27-char base62)"],
+  // nanoid — 21-char URL-safe (A-Za-z0-9_-). Exact 21 avoids over-matching short slugs.
+  [/^[A-Za-z0-9_-]{21}$/, "{id}", "nanoid (21-char)"],
+  // cuid / cuid2 — starts with 'c' then 24+ lowercase alphanumeric
+  [/^c[a-z0-9]{24,}$/, "{id}", "cuid/cuid2"],
+  // Stripe-style prefixed ids — e.g. cus_, price_, prod_, sub_, ch_, in_, etc.
+  [/^[a-z]{2,10}_[A-Za-z0-9]{14,}$/, "{id}", "Stripe-style prefixed id"],
+  // base62-ish opaque ids — 16+ alphanumeric with mixed case (case-sensitive)
+  [/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[A-Za-z0-9_-]{16,}$/, "{id}", "base62 mixed-case id"],
 ]
 
 // Tight static patterns — anything unrecognized falls through to "ambiguous"
@@ -60,12 +66,21 @@ function classifySegment(segment: string): SegmentClassification {
   // indices align with tier 2 template segments.
   if (segment === "") return { kind: "static", literal: "", reason: "path root" }
 
+  // TypeID — <type>_<ulid> preserves the type prefix so polymorphic endpoints
+  // like /node/order_<ulid> vs /node/user_<ulid> do not collapse. The suffix is
+  // the 26-char ULID; the prefix is lowercase type discriminator.
+  const typeIdMatch = segment.match(/^([a-z][a-z0-9_]*)_([0-9A-HJKMNP-TV-Z]{26})$/i)
+  if (typeIdMatch) {
+    const prefix = typeIdMatch[1]!.toLowerCase()
+    return { kind: "dynamic", placeholder: `${prefix}_{ulid}`, reason: "TypeID (prefix + ULID)" }
+  }
+
   for (const [pattern, placeholder, reason] of DYNAMIC_PATTERNS) {
     if (pattern.test(segment)) return { kind: "dynamic", placeholder, reason }
   }
 
   for (const [pattern, reason] of STATIC_PATTERNS) {
-    if (pattern.test(segment)) return { kind: "static", literal: segment, reason }
+    if (pattern.test(segment)) return { kind: "static", literal: segment.toLowerCase(), reason }
   }
 
   return { kind: "ambiguous", literal: segment, reason: "no deterministic pattern matched" }

--- a/packages/cyberstrike/src/session/normalize/tier2.ts
+++ b/packages/cyberstrike/src/session/normalize/tier2.ts
@@ -160,6 +160,13 @@ export function scoreTemplate(
     if (isPlaceholder(tseg)) {
       // Don't let a known-static (non-empty) segment fill a placeholder slot.
       if (cls.kind === "static" && pseg !== "") return null
+      // For TypeID partial placeholder e.g. order_{ulid}, enforce prefix match
+      if (tseg.includes("_{ulid}")) {
+        const prefix = tseg.split("_{ulid}")[0]!
+        if (!pseg.startsWith(prefix + "_")) return null
+        const suffix = pseg.slice(prefix.length + 1)
+        if (!/^[0-9A-HJKMNP-TV-Z]{26}$/i.test(suffix)) return null
+      }
       score += 1
     } else {
       if (tseg !== pseg) return null
@@ -170,5 +177,6 @@ export function scoreTemplate(
 }
 
 function isPlaceholder(seg: string): boolean {
+  if (seg.includes("{") && seg.includes("}")) return true
   return seg.startsWith("{") && seg.endsWith("}") && seg.length > 2
 }

--- a/packages/cyberstrike/src/session/normalize/types.ts
+++ b/packages/cyberstrike/src/session/normalize/types.ts
@@ -13,15 +13,16 @@
 
 export type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS"
 
-export type Placeholder = "{id}" | "{uuid}" | "{hash}" | "{email}" | "{token}" | "{slug}"
+export type Placeholder = "{id}" | "{uuid}" | "{hash}" | "{email}" | "{token}" | "{slug}" | "{ulid}" | `${string}_{ulid}` | string
 
-export const ALLOWED_PLACEHOLDERS: ReadonlySet<Placeholder> = new Set([
+export const ALLOWED_PLACEHOLDERS: ReadonlySet<string> = new Set([
   "{id}",
   "{uuid}",
   "{hash}",
   "{email}",
   "{token}",
   "{slug}",
+  "{ulid}",
 ])
 
 // Tier 0 output — deterministic parse of the raw HTTP request.


### PR DESCRIPTION
## What does this PR do?

Fixes #97 — deterministic normalization fragments or over-merges for modern IDs (TypeID/ULID/KSUID/nanoid/cuid/Stripe/base62), case-sensitive IDs, matrix params, gRPC-Web and tRPC. The change extends Tier-0/Tier-1 to classify those IDs, preserve case for opaque IDs, strip `;` matrix params, and model gRPC-Web/tRPC as operations.

## Type of change

- [ ] Bug fix
- [ ] New feature / agent
- [ ] Security tool / MCP server / Bolt plugin
- [ ] Agent skill / knowledge base
- [ ] UI / TUI improvement
- [ ] Documentation
- [ ] Refactor / performance
- [ ] CI / infrastructure

## Security impact

- [ ] This PR adds or modifies tool execution (shell, file, network)
- [ ] This PR changes agent permissions or scope
- [ ] This PR modifies authentication / authorization logic
- [ ] This PR has no security impact

## How did you verify it works?

Verified with deterministic harness covering the five gaps and existing normalize tests.

## Checklist

- [ ] `bun turbo typecheck` passes
- [ ] Tested locally with at least one LLM provider
- [ ] PR is focused on a single change
- [ ] No secrets, credentials, or API keys in the diff
- [ ] Breaking changes are documented (if any)