### PR TITLE
README: fix unverifiable "first" claim, add AI red teaming framing to hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@
   </picture>
 </p>
 
-<h3 align="center">The first open-source AI agent built for offensive security.</h3>
+<h3 align="center">The provider-agnostic AI agent for offensive security.</h3>
 
 <p align="center">
-  Automated penetration testing from your terminal — plug in your Claude, GPT, or any LLM subscription<br>
+  Autonomous penetration testing and AI red teaming from your terminal — plug in your Claude, GPT, or any LLM subscription<br>
   and turn it into an autonomous red team agent with 13+ specialized agents, 7,600+ security skills, and 120+ OWASP test cases.<br>
   <b>150+ AI providers</b> &bull; <b>5,300+ models</b> &bull; <b>56+ built-in tools</b> &bull; <b>176+ MCP tools</b>
 </p>
@@ -326,7 +326,7 @@ All open source. All installable with `npx`. Plug them into CyberStrike or use t
 CyberStrike agents have direct access to **56+ tools** without any external dependencies:
 
 | Category              | Tools                                                                               |
-| --------------------- | ----------------------------------------------------------------------------------- |
+| --------------------- | ------------------------------------------------------------------------------------- |
 | **Execution**         | Shell (bash), file read/write/edit/patch, directory listing, batch operations       |
 | **Discovery**         | Web fetch, web search, code search, glob, grep, intel gathering                     |
 | **Offensive**         | HackBrowser, attack script execution, vulnerability reporting & triage              |
@@ -345,7 +345,7 @@ Plus a **plugin SDK** with 15+ hook types (tool interception, message transforma
 CyberStrike includes built-in post-exploitation capabilities across multiple platforms — no external tools required.
 
 | Platform       | Capabilities                                                                                                                                                                     |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **macOS**      | Chrome credential extraction, Keychain dumping, keylogging, TCC bypass, GateKeeper bypass, XProtect checks, SSH key extraction, DTrace system tracing                            |
 | **Windows**    | Post-exploitation hooks for privilege escalation and persistence                                                                                                                 |
 | **Linux/eBPF** | 29 kernel-level scripts — process execution monitoring, SSL/TLS sniffing, keystroke logging, namespace manipulation detection, rootkit detection, process/file/connection hiding |
@@ -412,7 +412,7 @@ Read the [Contributing Guide](./CONTRIBUTING.md) before submitting a PR. All con
 CyberStrike is the core platform. These MCP servers extend its capabilities:
 
 | Project                                                                | Domain                                  | Tools                                                       |
-| ---------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------- |
+| ---------------------------------------------------------------------- | ---------------------------------------- | ----------------------------------------------------------- |
 | **CyberStrike**                                                        | **Autonomous offensive security agent** | **13+ agents, 56+ tools, 7,600+ skills, 150+ AI providers** |
 | [cloud-audit-mcp](https://github.com/badchars/cloud-audit-mcp)         | Cloud security (AWS/Azure/GCP)          | 38 tools, 60+ checks                                        |
 | [github-security-mcp](https://github.com/badchars/github-security-mcp) | GitHub security posture                 | 39 tools, 45 checks                                         |

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ All open source. All installable with `npx`. Plug them into CyberStrike or use t
 CyberStrike agents have direct access to **56+ tools** without any external dependencies:
 
 | Category              | Tools                                                                               |
-| --------------------- | ------------------------------------------------------------------------------------- |
+| --------------------- | ----------------------------------------------------------------------------------- |
 | **Execution**         | Shell (bash), file read/write/edit/patch, directory listing, batch operations       |
 | **Discovery**         | Web fetch, web search, code search, glob, grep, intel gathering                     |
 | **Offensive**         | HackBrowser, attack script execution, vulnerability reporting & triage              |
@@ -345,7 +345,7 @@ Plus a **plugin SDK** with 15+ hook types (tool interception, message transforma
 CyberStrike includes built-in post-exploitation capabilities across multiple platforms — no external tools required.
 
 | Platform       | Capabilities                                                                                                                                                                     |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **macOS**      | Chrome credential extraction, Keychain dumping, keylogging, TCC bypass, GateKeeper bypass, XProtect checks, SSH key extraction, DTrace system tracing                            |
 | **Windows**    | Post-exploitation hooks for privilege escalation and persistence                                                                                                                 |
 | **Linux/eBPF** | 29 kernel-level scripts — process execution monitoring, SSL/TLS sniffing, keystroke logging, namespace manipulation detection, rootkit detection, process/file/connection hiding |
@@ -412,7 +412,7 @@ Read the [Contributing Guide](./CONTRIBUTING.md) before submitting a PR. All con
 CyberStrike is the core platform. These MCP servers extend its capabilities:
 
 | Project                                                                | Domain                                  | Tools                                                       |
-| ---------------------------------------------------------------------- | ---------------------------------------- | ----------------------------------------------------------- |
+| ---------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------- |
 | **CyberStrike**                                                        | **Autonomous offensive security agent** | **13+ agents, 56+ tools, 7,600+ skills, 150+ AI providers** |
 | [cloud-audit-mcp](https://github.com/badchars/cloud-audit-mcp)         | Cloud security (AWS/Azure/GCP)          | 38 tools, 60+ checks                                        |
 | [github-security-mcp](https://github.com/badchars/github-security-mcp) | GitHub security posture                 | 39 tools, 45 checks                                         |


### PR DESCRIPTION
## What does this PR do?

Two-line change to the README hero section, generated from a scheduled SEO/discoverability review of the org's public repos. Not merged, for your review only.

1. Replaces "The first open-source AI agent built for offensive security" with "The provider-agnostic AI agent for offensive security."

   Several comparable open-source AI pentesting/red-teaming agents were created before this repo (e.g. usestrix/strix, 0x4m4/hexstrike-ai, KeygraphHQ/shannon, JoasASantos/NeuroSploit all predate CyberStrike's Feb 2026 creation date). The "first" claim is not defensible and is a credibility risk if a visitor checks. The new line leans on a differentiator that is actually true and unique among comparable projects: 150+ LLM providers, no vendor lock-in.

2. Changes "Automated penetration testing from your terminal" to "Autonomous penetration testing and AI red teaming from your terminal."

   "AI red teaming" is the fastest-growing phrase in this space right now (120+ GitHub repos tagged `ai-red-teaming`, used by high-visibility 2026 entrants like Tencent/AI-Infra-Guard and microsoft/AI-Red-Teaming-Playground-Labs). CyberStrike already does red teaming work (see the Agents and Skills sections) but the word never appears in the hero copy that most visitors and search engines read first.

## Type of change

- [x] Documentation

## Security impact

- [x] This PR has no security impact

## How did you verify it works?

Text-only change to README.md, no code paths touched. Diff is limited to the two lines above; verified locally against the base branch before pushing.

## Checklist

- [x] PR is focused on a single change
- [x] No secrets, credentials, or API keys in the diff
- [ ] Breaking changes are documented (if any) — n/a, no breaking changes

---

This is one item from a broader SEO/discoverability report also covering the repo's GitHub topics, About description, and the org's other public repos (bolt, cyberstrike-firefox-ext, homebrew-tap). Full report was sent separately for review; nothing else was changed automatically.