### PR TITLE
fix: keep project memory paths within the project

### DIFF
--- a/packages/cyberstrike/src/memory/index.ts
+++ b/packages/cyberstrike/src/memory/index.ts
@@ -1,6 +1,5 @@
 import { Log } from "../util/log"
 import { Instance } from "../project/instance"
-import { Global } from "../global"
 import path from "path"
 import fs from "fs/promises"
 import { existsSync } from "fs"
@@ -9,22 +8,20 @@ const log = Log.create({ service: "memory" })
 
 export namespace Memory {
   /**
-   * Get the memory directory path
-   * Uses .cyberstrike/memory/ in project root or global config
+   * Get the project-scoped memory directory path
+   * Uses Instance.directory for non-Git projects and Instance.worktree otherwise
    */
   export function getMemoryDir(): string {
-    const projectMemory = path.join(Instance.worktree, ".cyberstrike", "memory")
-    if (existsSync(path.dirname(projectMemory))) {
-      return projectMemory
-    }
-    return path.join(Global.Path.config, "memory")
+    const root = Instance.worktree === "/" ? Instance.directory : Instance.worktree
+    return path.join(root, ".cyberstrike", "memory")
   }
 
   /**
    * Get the path to MEMORY.md (long-term memory)
    */
   export function getMemoryFile(): string {
-    return path.join(Instance.worktree, ".cyberstrike", "MEMORY.md")
+    const root = Instance.worktree === "/" ? Instance.directory : Instance.worktree
+    return path.join(root, ".cyberstrike", "MEMORY.md")
   }
 
   /**

--- a/packages/cyberstrike/test/memory/project-path.test.ts
+++ b/packages/cyberstrike/test/memory/project-path.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Memory } from "../../src/memory"
+import { tmpdir } from "../fixture/fixture"
+
+describe("memory project paths", () => {
+  test("uses the active project directory when no git worktree exists", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        expect(Memory.getMemoryDir()).toBe(path.join(tmp.path, ".cyberstrike", "memory"))
+        expect(Memory.getMemoryFile()).toBe(path.join(tmp.path, ".cyberstrike", "MEMORY.md"))
+
+        await Memory.appendToDailyMemory("project note")
+        await Memory.appendToLongTermMemory("project decision")
+
+        expect(
+          await fs.readFile(
+            path.join(tmp.path, ".cyberstrike", "memory", `${new Date().toISOString().split("T")[0]}.md`),
+            "utf8",
+          ),
+        ).toContain("project note")
+        expect(await fs.readFile(path.join(tmp.path, ".cyberstrike", "MEMORY.md"), "utf8")).toContain(
+          "project decision",
+        )
+      },
+    })
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes #132 by keeping memory files inside the active project when a non-Git project uses `/` as its worktree sentinel.

## Type of change

- [ ] Bug fix
- [ ] New feature / agent
- [ ] Security tool / MCP server / Bolt plugin
- [ ] Agent skill / knowledge base
- [ ] UI / TUI improvement
- [ ] Documentation
- [ ] Refactor / performance
- [ ] CI / infrastructure

## Security impact

- [ ] This PR adds or modifies tool execution (shell, file, network)
- [ ] This PR changes agent permissions or scope
- [ ] This PR modifies authentication / authorization logic
- [ ] This PR has no security impact

## How did you verify it works?

Added a regression test that writes both daily and long-term memory through a real temporary project and verifies both files are under `.cyberstrike` in that project. `bun test test/memory/project-path.test.ts`, package typecheck, and Prettier checks pass.

## Checklist

- [ ] `bun turbo typecheck` passes
- [ ] Tested locally with at least one LLM provider
- [ ] PR is focused on a single change
- [ ] No secrets, credentials, or API keys in the diff
- [ ] Breaking changes are documented (if any)