### PR TITLE
fix(memory): keep project memory paths within the project

### DIFF
--- a/packages/cyberstrike/src/memory/index.ts
+++ b/packages/cyberstrike/src/memory/index.ts
@@ -1,6 +1,5 @@
 import { Log } from "../util/log"
 import { Instance } from "../project/instance"
-import { Global } from "../global"
 import path from "path"
 import fs from "fs/promises"
 import { existsSync } from "fs"
@@ -9,22 +8,19 @@ const log = Log.create({ service: "memory" })
 
 export namespace Memory {
   /**
-   * Get the memory directory path
-   * Uses .cyberstrike/memory/ in project root or global config
+   * Get the project-scoped memory directory path
    */
   export function getMemoryDir(): string {
-    const projectMemory = path.join(Instance.worktree, ".cyberstrike", "memory")
-    if (existsSync(path.dirname(projectMemory))) {
-      return projectMemory
-    }
-    return path.join(Global.Path.config, "memory")
+    const root = Instance.worktree === "/" ? Instance.directory : Instance.worktree
+    return path.join(root, ".cyberstrike", "memory")
   }
 
   /**
    * Get the path to MEMORY.md (long-term memory)
    */
   export function getMemoryFile(): string {
-    return path.join(Instance.worktree, ".cyberstrike", "MEMORY.md")
+    const root = Instance.worktree === "/" ? Instance.directory : Instance.worktree
+    return path.join(root, ".cyberstrike", "MEMORY.md")
   }
 
   /**

--- a/packages/cyberstrike/test/memory/project-path.test.ts
+++ b/packages/cyberstrike/test/memory/project-path.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Memory } from "../../src/memory"
+
+describe("memory project paths", () => {
+  test("uses the active project directory when no git worktree exists", async () => {
+    const project = await fs.mkdtemp(path.join(os.homedir(), ".cyberstrike-memory-test-"))
+
+    try {
+      await Instance.provide({
+        directory: project,
+        fn: async () => {
+          expect(Memory.getMemoryDir()).toBe(path.join(project, ".cyberstrike", "memory"))
+          expect(Memory.getMemoryFile()).toBe(path.join(project, ".cyberstrike", "MEMORY.md"))
+
+          await Memory.appendToDailyMemory("project note")
+          await Memory.appendToLongTermMemory("project decision")
+
+          expect(
+            await fs.readFile(
+              path.join(project, ".cyberstrike", "memory", `${new Date().toISOString().split("T")[0]}.md`),
+              "utf8",
+            ),
+          ).toContain("project note")
+          expect(await fs.readFile(path.join(project, ".cyberstrike", "MEMORY.md"), "utf8")).toContain(
+            "project decision",
+          )
+        },
+      })
+    } finally {
+      await fs.rm(project, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes #132 by keeping memory files inside the active project when a non-Git project uses `/` as its worktree sentinel.

## Type of change

- [x] Bug fix
- [ ] New feature / agent
- [ ] Security tool / MCP server / Bolt plugin
- [ ] Agent skill / knowledge base
- [ ] UI / TUI improvement
- [ ] Documentation
- [x] Refactor / performance
- [ ] CI / infrastructure

## Security impact

- [x] This PR adds or modifies tool execution (shell, file, network)
- [x] This PR changes agent permissions or scope
- [ ] This PR modifies authentication / authorization logic
- [x] This PR has no security impact

## How did you verify it works?

The regression test writes daily and long-term memory through a real non-Git project and verifies both files are created under that project.

## Checklist

- [x] `bun turbo typecheck` passes
- [x] Tested locally with at least one LLM provider
- [x] PR is focused on a single change
- [x] No secrets, credentials, or API keys in the diff
- [x] Breaking changes are documented (if any)

